### PR TITLE
Misc fixes 20191106

### DIFF
--- a/lib/HTFeed/Stage/Fetch.pm
+++ b/lib/HTFeed/Stage/Fetch.pm
@@ -69,6 +69,7 @@ sub fix_line_endings {
 
         while( <INPUT> ) {
             s/\r\n$/\n/;     # convert CR LF to LF
+            s/\f//g; # strip out form feeds
             print OUTPUT $_;
         }
 

--- a/lib/HTFeed/Stage/ImageRemediate.pm
+++ b/lib/HTFeed/Stage/ImageRemediate.pm
@@ -222,6 +222,7 @@ sub _remediate_tiff {
             );
             my @imagemagick_remediable_errs = ('PhotometricInterpretation not defined',
                                                'ColorSpace value out of range: 2',
+                                               'WhiteBalance value out of range: 5',
                                               # wrong data type for tag - will get automatically stripped
                                                'Type mismatch for tag',
                                                # related to thumbnails, which imagemagick will strip


### PR DESCRIPTION
Tested with emu.300000433992 (form feeds) and uiuc.7165334 (tiff fields).