### PR TITLE
HT-2433: Construct staging dir based on object dir

### DIFF
--- a/etc/config_ingest_docker.yml
+++ b/etc/config_ingest_docker.yml
@@ -6,9 +6,7 @@ repository:
   link_dir: /sdr2/obj
   # The directory into which volumes will be loaded
   obj_dir: /sdr1/obj
-  obj_stage_dir: /sdr2/obj/.tmp
   backup_obj_dir: /htdataden
-  backup_obj_stage_dir: /htdataden/.tmp
 
 staging_root: /tmp/ingest
 sip_root: /tmp/stage

--- a/etc/config_test.yml
+++ b/etc/config_test.yml
@@ -24,9 +24,10 @@ repository:
   link_dir: /tmp/obj_link
   # The directory into which volumes will be loaded
   obj_dir: /tmp/obj
-  obj_stage_dir: /tmp/obj/.tmp
   backup_obj_dir: /tmp/obj_backup
-  backup_obj_stage_dir: /tmp/obj_backup/.tmp
 
 storage_classes:
   - HTFeed::Storage::LocalPairtree
+
+jhove: /usr/bin/jhove
+jhoveconf: /etc/jhove/jhove.conf

--- a/etc/sample_config/01_daemon.yml
+++ b/etc/sample_config/01_daemon.yml
@@ -4,7 +4,6 @@ repository:
   link_dir: /sdr1/obj
   # The directory into which volumes will be loaded 
   obj_dir: $current_sdr_bucket
-  obj_stage_dir: $current_sdr_bucket/.tmp
 
 staging:
   # where to look for material to ingest

--- a/lib/HTFeed/Storage.pm
+++ b/lib/HTFeed/Storage.pm
@@ -43,9 +43,12 @@ sub stage {
   my $self = shift;
   my $volume = $self->{volume};
   my $mets_source = $volume->get_mets_path();
+  get_logger()->trace("copying METS from: $mets_source");
   my $zip_source = $volume->get_zip_path();
+  get_logger()->trace("copying ZIP from: $mets_source");
 
   my $stage_path = $self->stage_path;
+  get_logger()->trace("staging to: $stage_path");
   my $err;
 
   $self->safe_make_path($stage_path);
@@ -115,20 +118,26 @@ sub object_path {
     s2ppchars($self->{objid}));
 }
 
+sub stage_path_from_base {
+  my $self = shift;
+  my $base = shift;
+
+  return sprintf('%s/.tmp/%s.%s',
+    $base,
+    $self->{namespace},
+    s2ppchars($self->{objid}));
+};
+
 sub stage_path {
   my $self = shift;
   my $config_key = shift;
 
-  return sprintf('%s/%s.%s',
-    get_config('repository'=>$config_key),
-    $self->{namespace},
-    s2ppchars($self->{objid}));
+  return $self->stage_path_from_base(get_config('repository' => $config_key));
 }
 
 sub move {
   my $self = shift;
   my $volume = $self->{volume};
-  my $stage_path = $self->stage_path;
   my $mets_stage = $self->mets_stage_path;
   my $zip_stage = $self->zip_stage_path;
 

--- a/lib/HTFeed/Storage/VersionedPairtree.pm
+++ b/lib/HTFeed/Storage/VersionedPairtree.pm
@@ -33,7 +33,7 @@ sub object_path {
 sub stage_path {
   my $self = shift;
 
-  $self->SUPER::stage_path('backup_obj_stage_dir');
+  $self->SUPER::stage_path('backup_obj_dir');
 }
 
 sub record_audit {

--- a/t/lib/HTFeed/Test/TempDirs.pm
+++ b/t/lib/HTFeed/Test/TempDirs.pm
@@ -37,7 +37,7 @@ sub staging_dirtypes {
 
 sub repo_dirtypes {
   my $self = shift;
-  return qw(link_dir obj_dir other_obj_dir obj_stage_dir backup_obj_dir backup_obj_stage_dir);
+  return qw(link_dir obj_dir other_obj_dir backup_obj_dir);
 }
 
 sub cleanup {

--- a/t/storage.t
+++ b/t/storage.t
@@ -401,7 +401,30 @@ describe "HTFeed::Storage" => sub {
         $storage->stage;
         $storage->clean_staging;
 
-        ok(! -e "$tmpdirs->{obj_stage_dir}/test.test");
+        ok(! -e "$tmpdirs->{obj_dir}/.tmp/test.test");
+      };
+    };
+
+    describe "#stage" => sub {
+      context "when the item is not in repository" => sub {
+        it "stages to the configured staging location" => sub {
+          my $storage = local_storage($tmpdirs, 'test', 'test');
+          $storage->stage;
+
+          ok(-e "$tmpdirs->{obj_dir}/.tmp/test.test/test.mets.xml");
+          ok(-e "$tmpdirs->{obj_dir}/.tmp/test.test/test.zip");
+        };
+      };
+
+      context "when the item is in the repository with a different storage path" => sub {
+        it "deposits to a staging area under that path" => sub {
+          make_old_version_other_dir(local_storage($tmpdirs, 'test','test'));
+          my $storage = local_storage($tmpdirs, 'test', 'test');
+          $storage->stage;
+
+          ok(-e "$tmpdirs->{other_obj_dir}/.tmp/test.test/test.mets.xml");
+          ok(-e "$tmpdirs->{other_obj_dir}/.tmp/test.test/test.zip");
+        };
       };
     };
 
@@ -452,8 +475,8 @@ describe "HTFeed::Storage" => sub {
         my $storage = versioned_storage($tmpdirs, 'test', 'test');
         $storage->stage;
 
-        ok(-e "$tmpdirs->{backup_obj_stage_dir}/test.test/test.mets.xml");
-        ok(-e "$tmpdirs->{backup_obj_stage_dir}/test.test/test.zip");
+        ok(-e "$tmpdirs->{backup_obj_dir}/.tmp/test.test/test.mets.xml");
+        ok(-e "$tmpdirs->{backup_obj_dir}/.tmp/test.test/test.zip");
       }
     };
 


### PR DESCRIPTION
In the case when an object was already in the repository but using a
different object path, the staging directory would not be on the correct
filesystem for the final move.