### PR TITLE
HT-2518 Move configuration for storage classes

### DIFF
--- a/etc/config_ingest_docker.yml
+++ b/etc/config_ingest_docker.yml
@@ -25,11 +25,7 @@ storage_classes:
     # The directory into which volumes will be loaded
     obj_dir: /sdr1/obj
   - class: HTFeed::Storage::VersionedPairtree
-    # The directory in which symbolic links will be created to each volume
-    link_dir: /sdr2/obj
-    # The directory into which volumes will be loaded
-    obj_dir: /sdr1/obj
-    backup_obj_dir: /htdataden
+    obj_dir: /htdataden
 
 jhove: /usr/bin/jhove
 jhoveconf: /etc/jhove/jhove.conf

--- a/etc/config_ingest_docker.yml
+++ b/etc/config_ingest_docker.yml
@@ -1,13 +1,5 @@
 feed_home: /usr/local/feed
 
-# for end-to-end testing in docker
-repository:
-  # The directory in which symbolic links will be created to each volume
-  link_dir: /sdr2/obj
-  # The directory into which volumes will be loaded
-  obj_dir: /sdr1/obj
-  backup_obj_dir: /htdataden
-
 staging_root: /tmp/ingest
 sip_root: /tmp/stage
 
@@ -27,8 +19,17 @@ xerces: /usr/local/feed/blib/bin/validateCache
 epubcheck: /usr/bin/java -jar /usr/bin/epubcheck
 
 storage_classes:
-  - HTFeed::Storage::LocalPairtree
-  - HTFeed::Storage::VersionedPairtree
+  - class: HTFeed::Storage::LocalPairtree
+    # The directory in which symbolic links will be created to each volume
+    link_dir: /sdr2/obj
+    # The directory into which volumes will be loaded
+    obj_dir: /sdr1/obj
+  - class: HTFeed::Storage::VersionedPairtree
+    # The directory in which symbolic links will be created to each volume
+    link_dir: /sdr2/obj
+    # The directory into which volumes will be loaded
+    obj_dir: /sdr1/obj
+    backup_obj_dir: /htdataden
 
 jhove: /usr/bin/jhove
 jhoveconf: /etc/jhove/jhove.conf

--- a/etc/config_test.yml
+++ b/etc/config_test.yml
@@ -32,7 +32,6 @@ storage_classes:
     link_dir: /tmp/obj_link
     # The directory into which volumes will be loaded
     obj_dir: /tmp/obj
-    backup_obj_dir: /tmp/obj_backup
 
 jhove: /usr/bin/jhove
 jhoveconf: /etc/jhove/jhove.conf

--- a/etc/config_test.yml
+++ b/etc/config_test.yml
@@ -27,7 +27,12 @@ repository:
   backup_obj_dir: /tmp/obj_backup
 
 storage_classes:
-  - HTFeed::Storage::LocalPairtree
+  - class: HTFeed::Storage::LocalPairtree
+    # The directory in which symbolic links will be created to each volume
+    link_dir: /tmp/obj_link
+    # The directory into which volumes will be loaded
+    obj_dir: /tmp/obj
+    backup_obj_dir: /tmp/obj_backup
 
 jhove: /usr/bin/jhove
 jhoveconf: /etc/jhove/jhove.conf

--- a/lib/HTFeed/Stage/Collate.pm
+++ b/lib/HTFeed/Stage/Collate.pm
@@ -31,7 +31,8 @@ sub storages_from_config {
 
   my @storages;
   foreach my $storage_class (@{get_config('storage_classes')}) {
-    push(@storages, $storage_class->new(volume => $self->{volume}));
+    push(@storages, $storage_class->{class}->new(volume => $self->{volume},
+                                                 config => $storage_class));
   }
 
   return @storages;

--- a/lib/HTFeed/Stage/Collate.pm
+++ b/lib/HTFeed/Stage/Collate.pm
@@ -30,9 +30,9 @@ sub storages_from_config {
   my $self = shift;
 
   my @storages;
-  foreach my $storage_class (@{get_config('storage_classes')}) {
-    push(@storages, $storage_class->{class}->new(volume => $self->{volume},
-                                                 config => $storage_class));
+  foreach my $storage_config (@{get_config('storage_classes')}) {
+    push(@storages, $storage_config->{class}->new(volume => $self->{volume},
+                                                 config => $storage_config));
   }
 
   return @storages;

--- a/lib/HTFeed/Storage.pm
+++ b/lib/HTFeed/Storage.pm
@@ -17,18 +17,40 @@ sub new {
   die("Missing required argument 'volume'")
     unless $args{volume};
 
-  my $volume = $args{volume};
+  die("Missing required argument 'config'")
+    unless $args{volume};
 
+
+  my $volume = $args{volume};
+  my $config = $args{config};
 
   my $self = {
     volume => $volume,
     namespace => $volume->get_namespace(),
     objid => $volume->get_objid(),
     errors => [],
+    config => $config,
   };
 
   bless($self, $class);
   return $self;
+}
+
+# Should only be used for testing.
+sub get_storage_config {
+  my $self = shift;
+  my $key  = shift;
+
+  return $self->{config}->{$key};
+}
+
+# Ditto
+sub set_storage_config {
+  my $self  = shift;
+  my $value = shift;
+  my $key   = shift;
+
+  $self->{config}->{$key} = $value;
 }
 
 sub make_object_path {
@@ -112,7 +134,7 @@ sub object_path {
   my $config_key = shift;
 
   return sprintf('%s/%s/%s%s',
-    get_config('repository'=>$config_key),
+    $self->{config}->{$config_key},
     $self->{namespace},
     id2ppath($self->{objid}),
     s2ppchars($self->{objid}));
@@ -132,7 +154,7 @@ sub stage_path {
   my $self = shift;
   my $config_key = shift;
 
-  return $self->stage_path_from_base(get_config('repository' => $config_key));
+  return $self->stage_path_from_base($self->{config}->{$config_key});
 }
 
 sub move {

--- a/lib/HTFeed/Storage.pm
+++ b/lib/HTFeed/Storage.pm
@@ -18,7 +18,7 @@ sub new {
     unless $args{volume};
 
   die("Missing required argument 'config'")
-    unless $args{volume};
+    unless $args{config};
 
 
   my $volume = $args{volume};
@@ -34,23 +34,6 @@ sub new {
 
   bless($self, $class);
   return $self;
-}
-
-# Should only be used for testing.
-sub get_storage_config {
-  my $self = shift;
-  my $key  = shift;
-
-  return $self->{config}->{$key};
-}
-
-# Ditto
-sub set_storage_config {
-  my $self  = shift;
-  my $value = shift;
-  my $key   = shift;
-
-  $self->{config}->{$key} = $value;
 }
 
 sub make_object_path {

--- a/lib/HTFeed/Storage/LocalPairtree.pm
+++ b/lib/HTFeed/Storage/LocalPairtree.pm
@@ -4,7 +4,6 @@ use HTFeed::Storage;
 use base qw(HTFeed::Storage);
 
 use strict;
-use HTFeed::Config qw(get_config);
 use Log::Log4perl qw(get_logger);
 use File::Pairtree qw(id2ppath s2ppchars);
 use File::Path qw(make_path);
@@ -32,7 +31,7 @@ sub stage_path {
 sub uses_linked_objdir {
   my $self = shift;
 
-  return $self->{config}->{link_dir} ne $self->{config}->{obj_dir};
+  return $self->{config}{link_dir} ne $self->{config}{obj_dir};
 }
 
 sub existing_object_tmpdir {
@@ -151,7 +150,7 @@ sub make_link {
 
 sub link_parent {
   my $self = shift;
-  return sprintf('%s/%s/%s',$self->get_storage_config('link_dir'),$self->{namespace},id2ppath($self->{objid}));
+  return sprintf('%s/%s/%s',$self->{config}{link_dir},$self->{namespace},id2ppath($self->{objid}));
 }
 
 sub link_path {

--- a/lib/HTFeed/Storage/LocalPairtree.pm
+++ b/lib/HTFeed/Storage/LocalPairtree.pm
@@ -30,7 +30,9 @@ sub stage_path {
 }
 
 sub uses_linked_objdir {
-  return get_config('repository'=>'link_dir') ne get_config('repository'=>'obj_dir');
+  my $self = shift;
+
+  return $self->{config}->{link_dir} ne $self->{config}->{obj_dir};
 }
 
 sub existing_object_tmpdir {
@@ -149,7 +151,7 @@ sub make_link {
 
 sub link_parent {
   my $self = shift;
-  return sprintf('%s/%s/%s',get_config('repository','link_dir'),$self->{namespace},id2ppath($self->{objid}));
+  return sprintf('%s/%s/%s',$self->get_storage_config('link_dir'),$self->{namespace},id2ppath($self->{objid}));
 }
 
 sub link_path {

--- a/lib/HTFeed/Storage/VersionedPairtree.pm
+++ b/lib/HTFeed/Storage/VersionedPairtree.pm
@@ -26,14 +26,14 @@ sub object_path {
 
   $self->{timestamp} ||= strftime("%Y%m%d%H%M%S",gmtime);
 
-  $self->SUPER::object_path('backup_obj_dir') .
+  $self->SUPER::object_path('obj_dir') .
     "/" . $self->{timestamp};
 }
 
 sub stage_path {
   my $self = shift;
 
-  $self->SUPER::stage_path('backup_obj_dir');
+  $self->SUPER::stage_path('obj_dir');
 }
 
 sub record_audit {

--- a/t/collate.t
+++ b/t/collate.t
@@ -164,12 +164,17 @@ describe "HTFeed::Collate" => sub {
       my $old_storage_classes;
       before each => sub {
         $old_storage_classes = get_config('storage_classes');
-        my $new_storage_classes = [{class => 'HTFeed::Storage::LocalPairtree'},
-                                   {class => 'HTFeed::Storage::VersionedPairtree'}];
-        my $repo = get_config('repository');
-        foreach my $class (@$new_storage_classes) {
-          $class = {%$class, %$repo};
-        }
+        my $new_storage_classes = [
+          {
+            class => 'HTFeed::Storage::LocalPairtree',
+            obj_dir => $tmpdirs->{obj_dir},
+            link_dir => $tmpdirs->{link_dir}
+          },
+          {
+            class => 'HTFeed::Storage::VersionedPairtree',
+            obj_dir => $tmpdirs->{backup_obj_dir}
+          }
+        ];
         set_config($new_storage_classes,'storage_classes');
       };
 
@@ -192,8 +197,8 @@ describe "HTFeed::Collate" => sub {
         ok(-e "$tmpdirs->{obj_dir}/test/pairtree_root/te/st/test/test.mets.xml",'copies mets to local storage');
         ok(-e "$tmpdirs->{obj_dir}/test/pairtree_root/te/st/test/test.zip",'copies zip to local storage');
 
-        ok(-e "$tmpdirs->{obj_dir}/test/pairtree_root/te/st/test/$timestamp/test.zip","copies the zip to backup storage");
-        ok(-e "$tmpdirs->{obj_dir}/test/pairtree_root/te/st/test/$timestamp/test.mets.xml","copies the mets backup storage");
+        ok(-e "$tmpdirs->{backup_obj_dir}/test/pairtree_root/te/st/test/$timestamp/test.zip","copies the zip to backup storage");
+        ok(-e "$tmpdirs->{backup_obj_dir}/test/pairtree_root/te/st/test/$timestamp/test.mets.xml","copies the mets backup storage");
 
         ok(! -e "$tmpdirs->{zip}/test/00000001.jp2","cleans up the extracted zip files");
         ok(! -e "$tmpdirs->{zip}/test","cleans up the zip file tmpdir");

--- a/t/collate.t
+++ b/t/collate.t
@@ -192,8 +192,8 @@ describe "HTFeed::Collate" => sub {
         ok(-e "$tmpdirs->{obj_dir}/test/pairtree_root/te/st/test/test.mets.xml",'copies mets to local storage');
         ok(-e "$tmpdirs->{obj_dir}/test/pairtree_root/te/st/test/test.zip",'copies zip to local storage');
 
-        ok(-e "$tmpdirs->{backup_obj_dir}/test/pairtree_root/te/st/test/$timestamp/test.zip","copies the zip to backup storage");
-        ok(-e "$tmpdirs->{backup_obj_dir}/test/pairtree_root/te/st/test/$timestamp/test.mets.xml","copies the mets backup storage");
+        ok(-e "$tmpdirs->{obj_dir}/test/pairtree_root/te/st/test/$timestamp/test.zip","copies the zip to backup storage");
+        ok(-e "$tmpdirs->{obj_dir}/test/pairtree_root/te/st/test/$timestamp/test.mets.xml","copies the mets backup storage");
 
         ok(! -e "$tmpdirs->{zip}/test/00000001.jp2","cleans up the extracted zip files");
         ok(! -e "$tmpdirs->{zip}/test","cleans up the zip file tmpdir");

--- a/t/collate.t
+++ b/t/collate.t
@@ -164,7 +164,13 @@ describe "HTFeed::Collate" => sub {
       my $old_storage_classes;
       before each => sub {
         $old_storage_classes = get_config('storage_classes');
-        set_config(['HTFeed::Storage::LocalPairtree','HTFeed::Storage::VersionedPairtree'],'storage_classes');
+        my $new_storage_classes = [{class => 'HTFeed::Storage::LocalPairtree'},
+                                   {class => 'HTFeed::Storage::VersionedPairtree'}];
+        my $repo = get_config('repository');
+        foreach my $class (@$new_storage_classes) {
+          $class = {%$class, %$repo};
+        }
+        set_config($new_storage_classes,'storage_classes');
       };
 
       after each => sub {
@@ -183,7 +189,6 @@ describe "HTFeed::Collate" => sub {
         is(scalar(@{$backups}),1,'records a backup');
 
         my $timestamp = $backups->[0][0];
-
         ok(-e "$tmpdirs->{obj_dir}/test/pairtree_root/te/st/test/test.mets.xml",'copies mets to local storage');
         ok(-e "$tmpdirs->{obj_dir}/test/pairtree_root/te/st/test/test.zip",'copies zip to local storage');
 

--- a/t/lib/HTFeed/Test/TempDirs.pm
+++ b/t/lib/HTFeed/Test/TempDirs.pm
@@ -46,6 +46,22 @@ sub cleanup {
   remove_tree($self->{tmpdir});
 }
 
+sub config_for_storage_class {
+  my $self  = shift;
+  my $class = shift;
+
+  my $tmpdir = $self->{tmpdir};
+  my $config = {};
+
+  foreach my $dirtype ($self->repo_dirtypes) {
+    unless (exists $self->{$dirtype}) {
+      $self->{$dirtype} = tempdir("$tmpdir/feed-test-$dirtype-XXXXXX");
+    }
+    $config->{$dirtype} = $self->{$dirtype};
+  }
+  return $config;
+}
+
 sub setup_example {
   my $self = shift;
 

--- a/t/lib/HTFeed/Test/TempDirs.pm
+++ b/t/lib/HTFeed/Test/TempDirs.pm
@@ -5,7 +5,7 @@ use File::Basename qw(dirname);
 use File::Temp qw(tempdir);
 use File::Path qw(remove_tree);
 use Cwd qw(abs_path);
-use HTFeed::Config qw(set_config);
+use HTFeed::Config qw(set_config get_config);
 
 use warnings;
 use strict;
@@ -59,6 +59,11 @@ sub setup_example {
   foreach my $dirtype ($self->repo_dirtypes) {
     $self->{$dirtype} = tempdir("$tmpdir/feed-test-$dirtype-XXXXXX");
     set_config($self->{$dirtype},'repository',$dirtype);
+    my $storage_classes = get_config('storage_classes');
+    foreach my $storage_class (@$storage_classes) {
+      $storage_class->{$dirtype} = $self->{$dirtype};
+    }
+    set_config($storage_classes,'storage_classes');
   }
 }
 

--- a/t/lib/HTFeed/Test/TempDirs.pm
+++ b/t/lib/HTFeed/Test/TempDirs.pm
@@ -5,7 +5,7 @@ use File::Basename qw(dirname);
 use File::Temp qw(tempdir);
 use File::Path qw(remove_tree);
 use Cwd qw(abs_path);
-use HTFeed::Config qw(set_config get_config);
+use HTFeed::Config qw(set_config);
 
 use warnings;
 use strict;
@@ -46,22 +46,6 @@ sub cleanup {
   remove_tree($self->{tmpdir});
 }
 
-sub config_for_storage_class {
-  my $self  = shift;
-  my $class = shift;
-
-  my $tmpdir = $self->{tmpdir};
-  my $config = {};
-
-  foreach my $dirtype ($self->repo_dirtypes) {
-    unless (exists $self->{$dirtype}) {
-      $self->{$dirtype} = tempdir("$tmpdir/feed-test-$dirtype-XXXXXX");
-    }
-    $config->{$dirtype} = $self->{$dirtype};
-  }
-  return $config;
-}
-
 sub setup_example {
   my $self = shift;
 
@@ -74,12 +58,7 @@ sub setup_example {
 
   foreach my $dirtype ($self->repo_dirtypes) {
     $self->{$dirtype} = tempdir("$tmpdir/feed-test-$dirtype-XXXXXX");
-    set_config($self->{$dirtype},'repository',$dirtype);
-    my $storage_classes = get_config('storage_classes');
-    foreach my $storage_class (@$storage_classes) {
-      $storage_class->{$dirtype} = $self->{$dirtype};
-    }
-    set_config($storage_classes,'storage_classes');
+
   }
 }
 


### PR DESCRIPTION
…e class rather than global

CAVEATS

- `Volume.pm` is still using the `repository` version of the `link_dir` config since it doesn't have access to a storage instance. I assume that can be fixed on a related ticket like HT-2519.
- `collate.t` uses `repository` config when creating a set of storage classes on the fly.