### PR TITLE
HT-2520: Validate zip contents before staging

### DIFF
--- a/lib/HTFeed/Stage/Collate.pm
+++ b/lib/HTFeed/Stage/Collate.pm
@@ -77,6 +77,7 @@ sub collate {
   my $self = shift;
   my $storage = shift;
 
+  $storage->zipvalidate &&
   $storage->stage &&
   $storage->prevalidate &&
   $storage->make_object_path &&

--- a/lib/HTFeed/Storage.pm
+++ b/lib/HTFeed/Storage.pm
@@ -188,26 +188,16 @@ sub postvalidate {
   $self->validate_zip($self->object_path);
 }
 
-sub prevalidate {
+sub zipvalidate {
   my $self = shift;
-
-  $self->validate_mets($self->stage_path) &&
-  $self->validate_zip($self->stage_path) &&
-  $self->validate_zip_contents($self->stage_path);
-}
-
-# TODO move this to pack
-sub validate_zip_contents {
-  my $self = shift;
-  my $path = shift;
 
   my $volume = $self->{volume};
   my $pt_objid = $volume->get_pt_objid();
 
   my $zip_stage = get_config('staging'=>'zip') . "/$pt_objid";
 
-  my $mets_path = $volume->get_mets_path($path);
-  my $zip_path = $volume->get_zip_path($path);
+  my $mets_path = $volume->get_mets_path();
+  my $zip_path = $volume->get_zip_path();
   HTFeed::Stage::Unpack::unzip_file($self,$zip_path,$zip_stage);
   my $checksums = $volume->get_checksum_mets($mets_path);
   my $files = $volume->get_all_directory_files($zip_stage);
@@ -216,7 +206,13 @@ sub validate_zip_contents {
   remove_tree($zip_stage);
 
   return $ok;
-  #
+}
+
+sub prevalidate {
+  my $self = shift;
+
+  $self->validate_mets($self->stage_path) &&
+  $self->validate_zip($self->stage_path)
 }
 
 sub validate_mets {

--- a/t/collate.t
+++ b/t/collate.t
@@ -16,13 +16,25 @@ describe "HTFeed::Collate" => sub {
 
     before each => sub {
       $storage = Test::MockObject->new();
-      $storage->set_true(qw(stage prevalidate make_object_path move postvalidate record_audit cleanup rollback clean_staging));
+      $storage->set_true(qw(stage zipvalidate prevalidate make_object_path move postvalidate record_audit cleanup rollback clean_staging));
 
       my $volume = HTFeed::Volume->new(namespace => 'test',
         id => 'test',
         packagetype => 'simple');
       $collate = HTFeed::Stage::Collate->new(volume => $volume);
 
+    };
+
+    context "when zip contents validation fails" => sub {
+      before each => sub {
+        $storage->set_false('zipvalidate');
+      };
+
+      it "doesn't move to staging area" => sub {
+        $collate->run($storage);
+
+        ok(!$storage->called('stage'));
+      };
     };
 
     context "when prevalidation fails" => sub {

--- a/t/storage.t
+++ b/t/storage.t
@@ -187,6 +187,28 @@ describe "HTFeed::Storage" => sub {
       };
     };
 
+    describe "#zipvalidate" => sub {
+      context "with a zip whose contents do not match the METS" => sub {
+        it "returns false" => sub {
+          my $storage = local_storage($tmpdirs,'test','bad_file_checksum');
+          ok(!$storage->zipvalidate);
+        };
+
+        it "logs an error about the file" => sub {
+          my $storage = local_storage($tmpdirs,'test','bad_file_checksum');
+          $storage->zipvalidate;
+
+          ok($testlog->matches(qr(ERROR.*Checksum.*00000001.jp2)));
+        };
+      };
+
+      it "with a zip whose contents match the METS returns true" => sub {
+        my $storage = local_storage($tmpdirs,'test','test');
+        $storage->stage;
+        ok($storage->zipvalidate);
+      };
+    };
+
     describe "#prevalidate" => sub {
 
       context "with a zip whose checksum does not match the one in the METS" => sub {
@@ -237,23 +259,7 @@ describe "HTFeed::Storage" => sub {
         };
       };
 
-      context "with a zip whose contents do not match the METS" => sub {
-        it "returns false" => sub {
-          my $storage = local_storage($tmpdirs,'test','bad_file_checksum');
-          $storage->stage;
-          ok(!$storage->prevalidate);
-        };
-
-        it "logs an error about the file" => sub {
-          my $storage = local_storage($tmpdirs,'test','bad_file_checksum');
-          $storage->stage;
-          $storage->prevalidate;
-
-          ok($testlog->matches(qr(ERROR.*Checksum.*00000001.jp2)));
-        };
-      };
-
-      it "with a zip whose checksum and contents match the METS returns true" => sub {
+      it "with a zip whose checksum matches the METS returns true" => sub {
         my $storage = local_storage($tmpdirs,'test','test');
         $storage->stage;
         ok($storage->prevalidate);


### PR DESCRIPTION
The original issue specifies validating the zip contents in pack, but on
reflection that won't really work since the METS isn't constructed yet.
We could run the validation at the end of the METS stage or in an
additional stage before handle, but running at the beginning of collate
(i.e. before staging) seemed like a less disruptive change for the time
being.