### PR TITLE
HT-2738 virus scan stage for FRAME/EMMA

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ before_install:
   - git submodule update --init metslib
   - docker-compose build
   - docker-compose up -d mariadb
+  - docker-compose up -d clamav
 
 script:
   - docker-compose run travis_test

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ services:
 before_install:
   - git submodule update --init metslib
   - docker-compose build
-  - docker-compose up -d mariadb
-  - docker-compose up -d clamav
+  - docker-compose up -d mariadb clamav
+  - docker-compose run test bin/setup_dev.sh
 
 script:
-  - docker-compose run travis_test
+  - docker-compose run test

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,14 @@
 
 FROM hathitrust/feed_base:buster
 
-RUN apt-get install -y libtest-class-perl libswitch-perl libtest-spec-perl epubcheck netcat libtest-mockobject-perl
-RUN apt-get install -y libclamav-client-perl
+RUN apt-get update && apt-get install -y \
+    epubcheck \
+    libclamav-client-perl \
+    libswitch-perl \
+    libtest-class-perl \
+    libtest-mockobject-perl \
+    libtest-spec-perl \
+    netcat
 
 RUN mkdir -p /tmp/stage/grin
 RUN mkdir -p /tmp/prep/toingest /tmp/prep/failed /tmp/prep/ingested /tmp/prep/logs

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@
 FROM hathitrust/feed_base:buster
 
 RUN apt-get install -y libtest-class-perl libswitch-perl libtest-spec-perl epubcheck netcat libtest-mockobject-perl
+RUN apt-get install -y libclamav-client-perl
 
 RUN mkdir -p /tmp/stage/grin
 RUN mkdir -p /tmp/prep/toingest /tmp/prep/failed /tmp/prep/ingested /tmp/prep/logs

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,4 @@ RUN apt-get update && apt-get install -y \
 RUN mkdir -p /tmp/stage/grin
 RUN mkdir -p /tmp/prep/toingest /tmp/prep/failed /tmp/prep/ingested /tmp/prep/logs
 
-COPY . /usr/local/feed
 WORKDIR /usr/local/feed
-RUN bin/setup_dev.sh
-RUN ln -sf /usr/local/feed/t/fixtures/UNDAMAGED /tmp/prep/UNDAMAGED
-RUN ln -sf /usr/local/feed/t/fixtures/DAMAGED /tmp/prep/DAMAGED

--- a/README.md
+++ b/README.md
@@ -7,20 +7,18 @@ git clone https://github.com/hathitrust/feed
 cd feed
 git submodule update --init metslib
 docker-compose build
-```
-
-Running tests as in continuous integration
-
-```bash
-docker-compose run travis_test
-```
-
-Development
-
-```bash
-docker-compose up -d mariadb
-# Wait a few minutes for MariaDB to come up
 docker-compose run test bin/setup_dev.sh
+```
+
+# Development
+
+Start services via Docker if necessary:
+```
+docker-compose up -d mariadb clamav
+```
+
+Then:
+```
 docker-compose run test make test
 ```
 
@@ -36,7 +34,7 @@ docker-compose run test perl -I lib t/storage.t
 
 Validating volumes
 
-* Put volumes in volumes_to_test
+* Put volumes in `volumes_to_test/`
 
 ```bash
 docker-compose run validate

--- a/bin/wait-for
+++ b/bin/wait-for
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # From https://github.com/eficode/wait-for
 
@@ -35,7 +35,7 @@ usage() {
   exitcode="$1"
   cat << USAGE >&2
 Usage:
-  $cmdname host:port [-t timeout] [-- command args]
+  $cmdname host:port [host:port ...] [-t timeout] [-- command args]
   -q | --quiet                        Do not output any status messages
   -t TIMEOUT | --timeout=timeout      Timeout in seconds, zero for no timeout
   -- COMMAND ARGS                     Execute command with args after the test finishes
@@ -46,9 +46,23 @@ USAGE
 wait_for() {
   command="$*"
   for i in `seq $TIMEOUT` ; do
-    nc -z "$HOST" "$PORT" > /dev/null 2>&1
-    
-    result=$?
+
+    result=0
+
+    for dep in $DEPENDENCIES; do
+      host=$(printf "%s\n" "$dep"| cut -d : -f 1)
+      port=$(printf "%s\n" "$dep"| cut -d : -f 2)
+      if [ "$host" = "" -o "$port" = "" ]; then
+        echoerr "Error: you need to provide a host and port to test."
+        usage 2
+      fi
+      nc -z "$host" "$port" > /dev/null 2>&1
+      nc_result=$?
+      if [ $nc_result -ne 0 ] ; then
+        result=1
+      fi
+    done
+
     if [ $result -eq 0 ] ; then
       if [ -n "$command" ] ; then
         exec $command
@@ -61,12 +75,12 @@ wait_for() {
   exit 1
 }
 
+DEPENDENCIES=""
 while [ $# -gt 0 ]
 do
   case "$1" in
     *:* )
-    HOST=$(printf "%s\n" "$1"| cut -d : -f 1)
-    PORT=$(printf "%s\n" "$1"| cut -d : -f 2)
+    DEPENDENCIES+=" $1"
     shift 1
     ;;
     -q | --quiet)
@@ -96,7 +110,7 @@ do
   esac
 done
 
-if [ "$HOST" = "" -o "$PORT" = "" ]; then
+if [ "${#DEPENDENCIES[@]}" -eq "0" ]; then
   echoerr "Error: you need to provide a host and port to test."
   usage 2
 fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,14 +22,20 @@ services:
       - HTFEED_CONFIG=/usr/local/feed/etc/config_test.yml
       - FEED_HOME=/usr/local/feed
       - TEST=1
+      - CLAMAV_HOST=clamav
+      - CLAMAV_PORT=3310
 
   travis_test:
     build: .
+    volumes:
+      - .:/usr/local/feed
     environment:
       - HTFEED_CONFIG=/usr/local/feed/etc/config_test.yml
       - FEED_HOME=/usr/local/feed
       - TEST=1
-    command: bin/wait-for --timeout=300 mariadb:3306 -- make test TEST_VERBOSE=1
+      - CLAMAV_HOST=clamav
+      - CLAMAV_PORT=3310
+    command: bin/wait-for --timeout=300 mariadb:3306 -- bin/wait-for --timeout=300 clamav:3310 -- make test TEST_VERBOSE=1
 
   validate:
     build: .
@@ -49,7 +55,21 @@ services:
 
       # TODO: handle server??
 
+  clamav:
+    image: openbridge/clamav
+    container_name: clamav
+    ports:
+      - 3310
+    tty: true
+    restart: unless-stopped
+    tmpfs: /var/cache
+    volumes:
+      - clamd_data:/var/lib/clamav
+      - .:/usr/local/feed
+
 volumes:
+  clamd_data:
+    driver: 'local'
   repository_link:
   repository_obj:
   backups:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       - TEST=1
       - CLAMAV_HOST=clamav
       - CLAMAV_PORT=3310
-    command: bin/wait-for --timeout=300 mariadb:3306 -- bin/wait-for --timeout=300 clamav:3310 -- make test TEST_VERBOSE=1
+    command: bin/wait-for --timeout=300 mariadb:3306 clamav:3310 -- make test TEST_VERBOSE=1
 
   validate:
     build: .
@@ -57,9 +57,6 @@ services:
 
   clamav:
     image: openbridge/clamav
-    container_name: clamav
-    ports:
-      - 3310
     tty: true
     restart: unless-stopped
     tmpfs: /var/cache

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,17 +24,6 @@ services:
       - TEST=1
       - CLAMAV_HOST=clamav
       - CLAMAV_PORT=3310
-
-  travis_test:
-    build: .
-    volumes:
-      - .:/usr/local/feed
-    environment:
-      - HTFEED_CONFIG=/usr/local/feed/etc/config_test.yml
-      - FEED_HOME=/usr/local/feed
-      - TEST=1
-      - CLAMAV_HOST=clamav
-      - CLAMAV_PORT=3310
     command: bin/wait-for --timeout=300 mariadb:3306 clamav:3310 -- make test TEST_VERBOSE=1
 
   validate:

--- a/etc/sample_config/00_base_config.yml
+++ b/etc/sample_config/00_base_config.yml
@@ -114,6 +114,7 @@ premis_tools:
   KDU_COMPRESS: qq(kdu_compress 6.4.0)
   EPUBCHECK: qq(epubcheck 4.0.2)
   MP3VAL: qq(mp3val 0.1.8)
+  CLAMAV: qq(ClamAV 0.102.3)
 
 
 #########################################

--- a/lib/HTFeed/PackageType/EMMA.pm
+++ b/lib/HTFeed/PackageType/EMMA.pm
@@ -41,9 +41,8 @@ our $config = {
     # what stage to run given the current state
     stage_map => {
         ready            => 'HTFeed::PackageType::EMMA::Unpack',
-        #        unpacked         => 'HTFeed::Stage::VirusScan',
-        #        scanned          => 'HTFeed::PackageType::EMMA::SourceMETS',
-        unpacked         => 'HTFeed::PackageType::EMMA::SourceMETS',
+        unpacked         => 'HTFeed::PackageType::EMMA::VirusScan',
+        scanned         => 'HTFeed::PackageType::EMMA::SourceMETS',
         src_metsed    => 'HTFeed::Stage::Pack',
         packed           => 'HTFeed::PackageType::EMMA::METS',
         metsed           => 'HTFeed::Stage::Handle',
@@ -55,7 +54,7 @@ our $config = {
     source_premis_events => [
         # creation - included manually
         'source_mets_creation',
-        #    'virus_scan', - TODO
+        'virus_scan',
         'page_md5_create',
         'mets_validation',
     ],
@@ -71,7 +70,7 @@ our $config = {
     # configured in config.yaml)
     premis_events => [
       # 'creation',
-        #        'virus_scan', - TODO
+        'virus_scan',
         'zip_compression',
         'zip_md5_create',
         'ingestion',
@@ -92,6 +91,13 @@ our $config = {
             executor => 'umich',
             executor_type => 'HathiTrust Institution ID',
             tools => ['DIGEST_MD5']
+          },
+          'virus_scan' => 
+          { type => 'virus scan',
+            detail => 'Scan for virus',
+            executor => 'umich',
+            executor_type => 'HathiTrust Institution ID',
+            tools => ['CLAMAV']
           }
         },
 

--- a/lib/HTFeed/PackageType/EMMA/METS.pm
+++ b/lib/HTFeed/PackageType/EMMA/METS.pm
@@ -14,7 +14,7 @@ sub new {
     );
     $self->{profile} = "http://www.hathitrust.org/documents/hathitrust-emma-mets-profile1.0.xml";
     #    $self->{required_events} = ["creation","message digest calculation","virus scan","ingestion"];
-    $self->{required_events} = ["message digest calculation","ingestion"];
+    $self->{required_events} = ["message digest calculation","virus scan","ingestion"];
 
     return $self;
 }

--- a/lib/HTFeed/PackageType/EMMA/VirusScan.pm
+++ b/lib/HTFeed/PackageType/EMMA/VirusScan.pm
@@ -1,0 +1,68 @@
+#!/usr/bin/perl
+
+package HTFeed::PackageType::EMMA::VirusScan;
+
+use warnings;
+use strict;
+use base qw(HTFeed::Stage);
+
+use Log::Log4perl qw(get_logger);
+use PREMIS::Outcome;
+use ClamAV::Client;
+
+sub new {
+  my $class = shift;
+
+  my $self = $class->SUPER::new(
+      @_,
+  );
+  my $scanner;
+  eval {
+    my $clamav_host = $ENV{CLAMAV_HOST} || '127.0.0.1';
+    my $clamav_port = $ENV{CLAMAV_PORT} || 3310;
+    $scanner = ClamAV::Client->new(socket_host => $clamav_host,
+                                   socket_port => $clamav_port);
+    $scanner->ping();
+  };
+  die "unable to connect to ClamAV: $@" if $@;
+  $self->{scanner} = $scanner;
+  return $self;
+}
+
+# Verifies that all content files pass ClamAV virus checks.
+sub run {
+  my $self   = shift;
+  my $volume = $self->{volume};
+  my $dest = $volume->get_staging_directory();
+
+  my $scanner = $self->{scanner};
+  my $files = $volume->get_all_content_files();
+  my $virus_count = 0;
+  foreach my $file (@$files) {
+    my ($path, $result) = $scanner->scan_path($dest . '/' . $file);
+    if (defined $result) {
+      $virus_count++;
+      $self->set_error("Virus", detail => "Virus detected in $file ($result)");
+    }
+  }
+  $self->_add_virus_scan_event($virus_count == 0);
+  $self->_set_done();
+  return $self->succeeded();
+}
+
+sub stage_info {
+  return {success_state => 'scanned', failure_state => 'punted'};
+}
+
+sub _add_virus_scan_event {
+  my $self      = shift;
+  my $succeeded = shift;
+
+  my $outcome = PREMIS::Outcome->new($succeeded ? 'pass' : 'fail');
+  $self->{volume}->record_premis_event('virus_scan',
+                                       outcome => $outcome,);
+}
+
+1;
+
+__END__

--- a/t/classtests.t
+++ b/t/classtests.t
@@ -7,7 +7,7 @@ use FindBin;
 use lib "$FindBin::Bin/lib";
 use lib "$FindBin::Bin/../lib";
 use HTFeed::Log {root_logger => 'INFO, screen'};
-use HTFeed::Config qw(set_config);
+use HTFeed::Config qw(set_config get_config);
 set_config('1','debug');
 use HTFeed::Test::Support qw(load_db_fixtures);
 
@@ -15,6 +15,12 @@ use HTFeed::Test::Support qw(load_db_fixtures);
 my $test_classes = HTFeed::Test::Support::get_test_classes();
 
 load_db_fixtures;
+
+my $undamaged = get_config('test_staging','undamaged');
+my $damaged = get_config('test_staging','damaged');
+
+symlink("$FindBin::Bin/fixtures/UNDAMAGED",$undamaged) if( ! -e $undamaged);
+symlink("$FindBin::Bin/fixtures/DAMAGED",$damaged) if( ! -e $damaged);
 
 # run the tests
 Test::Class->runtests( @$test_classes );

--- a/t/emma.t
+++ b/t/emma.t
@@ -33,6 +33,10 @@ shared_examples_for "an emma mets" => sub {
     ok($xc->findnodes('//premis:eventType[text()="message digest calculation"]')->size() == 1);
   };
 
+  it "has a PREMIS virus scan event" => sub {
+    ok($xc->findnodes('//premis:eventType[text()="virus scan"]')->size() == 1);
+  };
+
   it "has the EMMA metadata in a dmdSec" => sub {
     ok($xc->findnodes('//mets:dmdSec//emma:SubmissionPackage')->size() == 1);
   };
@@ -99,11 +103,28 @@ context "with volume & temporary ingest/preingest/zipfile dirs" => sub {
     };
   };
 
+  describe "HTFeed::PackageType::EMMA::VirusScan" => sub {
+    my $stage;
+
+    before each => sub {
+      my $unpack = HTFeed::PackageType::EMMA::Unpack->new(volume => $volume);
+      $unpack->run();
+      $stage = HTFeed::PackageType::EMMA::VirusScan->new(volume => $volume);
+
+    };
+
+    it "succeeds" => sub {
+      $stage->run();
+      ok($stage->succeeded());
+    };
+  };
+
   describe "HTFeed::PackageType::EMMA::SourceMETS" => sub {
     my $stage;
 
     before each => sub {
       HTFeed::PackageType::EMMA::Unpack->new(volume => $volume)->run();
+      HTFeed::PackageType::EMMA::VirusScan->new(volume => $volume)->run();
 
       $stage = HTFeed::PackageType::EMMA::SourceMETS->new(volume => $volume);
 
@@ -144,6 +165,7 @@ context "with volume & temporary ingest/preingest/zipfile dirs" => sub {
       mock_zephir();
 
       HTFeed::PackageType::EMMA::Unpack->new(volume => $volume)->run();
+      HTFeed::PackageType::EMMA::VirusScan->new(volume => $volume)->run();
       HTFeed::PackageType::EMMA::SourceMETS->new(volume => $volume)->run();
       HTFeed::Stage::Pack->new(volume => $volume)->run();
 


### PR DESCRIPTION
Not sure about adding `clamav` as a new Docker service. This will probably not run out of the box in a non-Docker environment. The `ClamAV::Client` module that I settled on as sorta supported, does not use the ClamAV API, rather it just talks to the ClamAV daemon and parses the results.