### PR TITLE
HT-2773: integration tests for objectstore

### DIFF
--- a/lib/HTFeed/Stage/Collate.pm
+++ b/lib/HTFeed/Stage/Collate.pm
@@ -15,6 +15,7 @@ use Carp qw(croak);
 use HTFeed::Storage::LocalPairtree;
 use HTFeed::Storage::LinkedPairtree;
 use HTFeed::Storage::VersionedPairtree;
+use HTFeed::Storage::ObjectStore;
 
 =head1 NAME
 

--- a/lib/HTFeed/Storage/ObjectStore.pm
+++ b/lib/HTFeed/Storage/ObjectStore.pm
@@ -39,6 +39,10 @@ sub object_path {
     $self->{timestamp});
 }
 
+sub clean_staging {
+  # No staging path, so nothing to clean
+}
+
 sub stage_path {
   die("Not implemented for ObjectStore");
 }
@@ -145,6 +149,11 @@ sub md5_base64 {
   # digests you might want to append the string "==" to the result.
 
   return Digest::MD5->new->addfile($fh)->b64digest . '==';
+}
+
+sub record_audit {
+  my $self = shift;
+  $self->record_backup;
 }
 
 sub record_backup {

--- a/t/storage_object_store.t
+++ b/t/storage_object_store.t
@@ -6,23 +6,8 @@ use strict;
 
 describe "HTFeed::Storage::ObjectStore" => sub {
   spec_helper 'storage_helper.pl';
+  spec_helper 's3_helper.pl';
   local our ($tmpdirs, $testlog, $bucket, $s3);
-
-  before all => sub {
-    $bucket = "bucket" . sprintf("%08d",rand(1000000));
-    $s3 = HTFeed::Storage::S3->new(
-      bucket => $bucket,
-      awscli => ['aws','--endpoint-url','http://minio:9000']
-    );
-    $ENV{AWS_MAX_ATTEMPTS} = 1;
-
-    $s3->mb;
-  };
-
-  after all => sub {
-    $s3->rm('/',"--recursive");
-    $s3->rb;
-  };
 
   sub object_storage {
     my $volume = stage_volume($tmpdirs,@_);


### PR DESCRIPTION
Notably, this handles the case when both versioned pairtree and
objectstore are configured; gpg complains when the crypted zip
already exists.