### PR TITLE
HT-2502: StorageMigrate wasn't copying from repository

### DIFF
--- a/lib/HTFeed/PackageType/HathiTrust/Volume.pm
+++ b/lib/HTFeed/PackageType/HathiTrust/Volume.pm
@@ -180,6 +180,21 @@ sub clean_download {
     return 1;
 }
 
+# Returns path to item in the repository rather than in the staging area
+sub get_mets_path {
+  my $self = shift;
+  my $path = shift || $self->get_repository_symlink;
+
+  return $self->SUPER::get_mets_path($path);
+}
+
+sub get_zip_path {
+  my $self = shift;
+  my $path = shift || $self->get_repository_symlink();
+
+  return $self->SUPER::get_zip_path($path);
+}
+
 
 
 1;

--- a/t/lib/HTFeed/Test/TempDirs.pm
+++ b/t/lib/HTFeed/Test/TempDirs.pm
@@ -56,6 +56,7 @@ sub setup_example {
 
   foreach my $dirtype ($self->repo_dirtypes) {
     $self->{$dirtype} = $self->dir_for($dirtype);
+    set_config($self->{$dirtype},'repository',$dirtype);
   }
 }
 

--- a/t/storage_migrate.t
+++ b/t/storage_migrate.t
@@ -46,14 +46,20 @@ describe "HTFeed::Stage::StorageMigrate" => sub {
 
     # deposit the test item in the main repository, but not to the configured
     # backup locations
-    my $local_storage = HTFeed::Storage::LocalPairtree->new(
+    my $local_storage = HTFeed::Storage::LinkedPairtree->new(
       volume => $init_volume,
-      config => { obj_dir => $tmpdirs->{obj_dir} }
+      config => { obj_dir => $tmpdirs->{obj_dir}, link_dir => $tmpdirs->{link_dir} }
     );
     my $collate = HTFeed::Stage::Collate->new(volume => $init_volume);
     $collate->run($local_storage);
-    ok($collate->succeeded());
+    ok($collate->succeeded(),'collate to repository succeeds');
 
+    # make sure we're copying from the repository, not from temporary
+    # directories, but leave them intact when we're done
+    foreach my $dirtype ($tmpdirs->staging_dirtypes) {
+      remove_tree $tmpdirs->{$dirtype};
+      mkdir $tmpdirs->{$dirtype};
+    }
 
     # then run the storage migration and make sure volumes show up in the
     # expected location


### PR DESCRIPTION
The storage_migrate.t test was previously succeeding because it was
copying from a staging area, not from the repository. This commit
adjusts the test so that it cleans out the staging area, then adjusts
the `HTFeed::PackageType::HathiTrust::Volume` to provide the path to the
mets and zip in the repository. It also adjusts `TempDirs` to properly use
temporary directories for the repository locations.