### PR TITLE
HT-2861: ensure we use staging area for saving .gpg

### DIFF
--- a/lib/HTFeed/Stage/Collate.pm
+++ b/lib/HTFeed/Stage/Collate.pm
@@ -4,6 +4,7 @@ use warnings;
 use strict;
 
 use base qw(HTFeed::Stage);
+use Log::Log4perl qw(get_logger);
 use HTFeed::Config qw(get_config);
 use Carp qw(croak);
 
@@ -39,8 +40,10 @@ sub run{
     foreach my $storage (@storages) {
 
       if( $self->collate($storage))  {
+        get_logger->trace("finished collate to $storage, cleaning up");
         $storage->cleanup
       } else {
+        get_logger->warn("collate to $storage failed, rolling back");
         $storage->rollback;
       }
 
@@ -69,6 +72,8 @@ sub log_repeat {
 sub collate {
   my $self = shift;
   my $storage = shift;
+
+  get_logger->trace("Starting collate for $storage");
 
   $storage->validate_zip_completeness &&
   $storage->encrypt &&

--- a/lib/HTFeed/Storage/ObjectStore.pm
+++ b/lib/HTFeed/Storage/ObjectStore.pm
@@ -117,7 +117,7 @@ sub postvalidate {
 sub move {
   my $self = shift;
   $self->put_object($self->mets_key,$self->{volume}->get_mets_path());
-  $self->put_object($self->zip_key,$self->zip_source);
+  $self->put_object($self->zip_key,$self->{zip_source});
 }
 
 sub put_object {

--- a/t/storage_versioned_pairtree.t
+++ b/t/storage_versioned_pairtree.t
@@ -198,9 +198,9 @@ describe "HTFeed::Storage::VersionedPairtree" => sub {
 
       it "fails with a corrupted encrypted zip" => sub {
         my $storage = encrypted_storage('test', 'test');
-        my $encrypted = $storage->zip_source . ".gpg";
 
         $storage->encrypt;
+        my $encrypted = $storage->zip_source;
 
         open(my $fh, "+< $encrypted") or die($!);
         seek($fh,0,0);


### PR DESCRIPTION
- Before, we just appended .gpg to whatever the source zip file was,
which left .gpg files sitting in the repository if something failed

- Also changes postvalidate for versioned pairtree just to check that
the files are in the final location -- i.e. assume that if mv actually
worked the files are the same as they were after prevalidate

- Adds some additional TRACE-level logging