### PR TITLE
HT-2524 cloud storage audit

### DIFF
--- a/bin/glacier_zip_audit.pl
+++ b/bin/glacier_zip_audit.pl
@@ -17,13 +17,15 @@ my $volume = HTFeed::GlacierZipAudit::choose();
 my $audit = HTFeed::GlacierZipAudit->new(namespace => $volume->{namespace},
                                          objid => $volume->{objid},
                                          path => $volume->{path},
-                                         version => $volume->{version});
+                                         version => $volume->{version},
+                                         storage_name => $volume->{storage_name});
 $audit->run();
 my $volumes = HTFeed::GlacierZipAudit->pending_objects();
 foreach my $volume (@$volumes) {
   my $audit = HTFeed::GlacierZipAudit->new(namespace => $volume->{namespace},
                                            objid => $volume->{objid},
                                            path => $volume->{path},
-                                           version => $volume->{version});
+                                           version => $volume->{version},
+                                           storage_name => $volume->{storage_name});
   my $result = $audit->run();
 }

--- a/bin/glacier_zip_audit.pl
+++ b/bin/glacier_zip_audit.pl
@@ -1,0 +1,29 @@
+#!/usr/bin/perl
+
+# Randomly chooses a Glacier Deep Storage object object to validate
+# and issues a restore request for it.
+# Checks other objects for which restores have been issued and runs validation
+# for any that are ready.
+# This script should be run daily, give or take.
+
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use HTFeed::GlacierZipAudit;
+use HTFeed::Log {root_logger => 'INFO, screen'};
+
+my $volume = HTFeed::GlacierZipAudit::choose();
+my $audit = HTFeed::GlacierZipAudit->new(namespace => $volume->{namespace},
+                                         objid => $volume->{objid},
+                                         path => $volume->{path},
+                                         version => $volume->{version});
+$audit->run();
+my $volumes = HTFeed::GlacierZipAudit->pending_objects();
+foreach my $volume (@$volumes) {
+  my $audit = HTFeed::GlacierZipAudit->new(namespace => $volume->{namespace},
+                                           objid => $volume->{objid},
+                                           path => $volume->{path},
+                                           version => $volume->{version});
+  my $result = $audit->run();
+}

--- a/bin/glacier_zip_audit.pl
+++ b/bin/glacier_zip_audit.pl
@@ -13,19 +13,17 @@ use lib "$FindBin::Bin/../lib";
 use HTFeed::GlacierZipAudit;
 use HTFeed::Log {root_logger => 'INFO, screen'};
 
-my $volume = HTFeed::GlacierZipAudit::choose();
-my $audit = HTFeed::GlacierZipAudit->new(namespace => $volume->{namespace},
-                                         objid => $volume->{objid},
-                                         path => $volume->{path},
-                                         version => $volume->{version},
-                                         storage_name => $volume->{storage_name});
-$audit->run();
-my $volumes = HTFeed::GlacierZipAudit->pending_objects();
+die "Specify a feed_backups.storage_name value" unless 1 == scalar @ARGV;
+my $storage_name = $ARGV[0];
+
+my $volume = HTFeed::GlacierZipAudit::choose($storage_name);
+if (defined $volume->{namespace} && defined $volume->{objid} &&
+    defined $volume->{path} && defined $volume->{version}) {
+  my $audit = HTFeed::GlacierZipAudit->new(%$volume);
+  $audit->run();
+}
+my $volumes = HTFeed::GlacierZipAudit->pending_objects($storage_name);
 foreach my $volume (@$volumes) {
-  my $audit = HTFeed::GlacierZipAudit->new(namespace => $volume->{namespace},
-                                           objid => $volume->{objid},
-                                           path => $volume->{path},
-                                           version => $volume->{version},
-                                           storage_name => $volume->{storage_name});
+  my $audit = HTFeed::GlacierZipAudit->new(%$volume);
   my $result = $audit->run();
 }

--- a/docker/database/sql/100_feed_schema.sql
+++ b/docker/database/sql/100_feed_schema.sql
@@ -120,6 +120,7 @@ CREATE TABLE IF NOT EXISTS `feed_backups` (
   `saved_md5sum` char(32) DEFAULT NULL,
   `lastchecked` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `lastmd5check` timestamp NULL DEFAULT NULL,
+  `restore_request` timestamp NULL DEFAULT NULL,
   `md5check_ok` tinyint(1) DEFAULT NULL,
   `deleted` tinyint(1) DEFAULT NULL,
   KEY `feed_backups_objid` (`namespace`,`id`),

--- a/lib/HTFeed/GlacierZipAudit.pm
+++ b/lib/HTFeed/GlacierZipAudit.pm
@@ -1,0 +1,246 @@
+#!/usr/bin/perl
+package HTFeed::GlacierZipAudit;
+
+use strict;
+use warnings;
+use HTFeed::DBTools qw(get_dbh);
+use HTFeed::Volume;
+use Carp;
+use Log::Log4perl;
+use File::Temp;
+
+# Procedural function for randomly choosing a volume to check.
+#
+# my $vol = HTFeed::GlacierZipAudit->choose();
+# my $audit = HTFeed::GlacierZipAudit->new(namespace => $vol->{namespace},
+#                                          objid => $vol->{objid},
+#                                          path => $vol->{path},
+#                                          version => $vol->{version});
+# $audit->submit_restore_object();
+#
+# later ...
+# 
+# my $volumes = HTFeed::GlacierZipAudit->pending_objects();
+# foreach my $vol (@$volumes) {
+#   my $audit = HTFeed::GlacierZipAudit->new(namespace => $vol->{namespace},
+#                                            objid => $vol->{objid},
+#                                            path => $vol->{path},
+#                                            version => $vol->{version});
+#  my $result = $audit->run();
+# }
+sub choose {
+  my $path_prefix = shift || 's3://ht-deep-archive-backup/';
+
+  my $dbh = HTFeed::DBTools->get_dbh();
+  my ($namespace, $objid, $path, $version);
+  my $sql = 'SELECT namespace,id,path,version FROM feed_backups' .
+            " WHERE path LIKE '$path_prefix%'" .
+            ' AND deleted IS NULL' .
+            ' AND saved_md5sum IS NOT NULL' .
+            ' AND restore_request IS NULL' .
+            ' ORDER BY RAND() LIMIT 1';
+  eval {
+    ($namespace, $objid, $path, $version) = $dbh->selectrow_array($sql);
+  };
+  if ($@) {
+    die "Database query failed: $@";
+  }
+  return { namespace => $namespace, objid => $objid,
+           path => $path, version => $version };
+}
+
+# Get the objects for which we have issued restore requests
+sub pending_objects {
+  my $path_prefix = shift || 's3://ht-deep-archive-backup/';
+
+  my $dbh = HTFeed::DBTools->get_dbh();
+  my ($namespace, $objid, $path, $version);
+  my $sql = 'SELECT namespace,id,path,version FROM feed_backups' .
+            " WHERE path LIKE '$path_prefix%'" .
+            ' AND restore_request IS NOT NULL';
+  my $pending = [];
+  eval {
+    my $ref = $dbh->selectall_arrayref($sql);
+    foreach my $row (@$ref) {
+      ($namespace, $objid, $path, $version) = @$row;
+      push @$pending, { namespace => $namespace, objid => $objid,
+           path => $path, version => $version };
+    }
+  };
+  if ($@) {
+    die "Database query failed: $@";
+  }
+  return $pending;
+}
+
+sub new {
+  my $class = shift;
+
+  my $self = {
+      @_,
+  };
+  if ( $class ne __PACKAGE__ ) {
+      croak "use __PACKAGE__ constructor to create $class object";
+  }
+  # check parameters
+  unless ($self->{namespace} && $self->{objid} && $self->{version} && 
+          $self->{s3} && $self->{bucket}) {
+    croak "invalid args: namespace, objid, version, s3, bucket required";
+  }
+
+  my $volume = HTFeed::Volume->new(
+    packagetype => 'pkgtype',
+    namespace   => $self->{namespace},
+    objid       => $self->{objid}
+  );
+  $self->{volume} = $volume;
+  # EVIL HACK that may break in production.
+  $self->{storage} ||= (HTFeed::Storage::for_volume($volume))[0];
+  
+  $self->{tmpdir} = File::Temp::tempdir();
+  $self->{zip_file} = join '.', ($self->{namespace}, $self->{objid}, $self->{version}, 'zip', 'gpg');
+  $self->{mets_file} = join '.', ($self->{namespace}, $self->{objid}, $self->{version}, 'mets', 'xml');
+  $self->{zip_path} = "$self->{tmpdir}/$self->{zip_file}";
+  $self->{mets_path} = "$self->{tmpdir}/$self->{mets_file}";
+  
+  bless( $self, $class );
+  return $self;
+}
+
+my $insert_detail =
+"insert into feed_audit_detail (namespace, id, path, status, detail) values (?,?,?,?,?)";
+
+my $update =
+"update feed_backups set md5check_ok = ?, lastmd5check = CURRENT_TIMESTAMP, restore_request = NULL where namespace = ? and id = ? and version = ?";
+
+my $select_checksum =
+"select saved_md5sum from feed_backups where namespace = ? AND id = ? AND version = ?";
+
+sub submit_restore_object {
+  my $self = shift;
+
+  my $req_json = '{"Days":10,"GlacierJobParameters":{"Tier":"Bulk"}}';
+  $self->{s3}->restore_object($self->{zip_file}, '--restore-request', $req_json);
+  $self->{s3}->restore_object($self->{mets_file}, '--restore-request', $req_json);
+  my $sql = 'UPDATE feed_backups SET restore_request=CURRENT_TIMESTAMP' .
+            ' WHERE namespace = ? AND id = ? AND version = ?';
+  eval {
+    HTFeed::DBTools->get_dbh()->prepare($sql)->execute($self->{namespace}, $self->{objid}, $self->{version});
+  };
+  if ($@) {
+    die "Database operation failed: $@";
+  }
+  return 1;
+}
+
+sub get_files {
+  my $self = shift;
+
+  return if $self->{get_files_complete};
+  $self->{s3}->get_object($self->{'bucket'}, $self->{zip_file}, $self->{zip_path});
+  $self->{s3}->get_object($self->{'bucket'}, $self->{mets_file}, $self->{mets_path});
+  $self->{get_files_complete} = 1;
+}
+
+# Returns 1 if both the zip and METS are ready for download.
+sub check_files {
+  my $self = shift;
+
+  $self->{check_files_complete} = 1;
+
+  my $result = $self->{s3}->head_object($self->{zip_file});
+  if ($result->{Restore} && $result->{Restore} =~ m/ongoing-request\s*=\s*"false"/) {
+    $result = $self->{s3}->head_object($self->{mets_file});
+    if ($result->{Restore} && $result->{Restore} =~ m/ongoing-request\s*=\s*"false"/) {
+      return 1;
+    }
+  }
+  return 0;
+}
+
+sub run {
+  my $self = shift;
+
+  return unless $self->check_files() == 1;
+  $self->get_files();
+  my ($db_ok, $mets_ok) = (0, 0);
+  eval {
+    die "encrypted zip $self->{zip_path} does not exist" unless -f $self->{zip_path};
+    $db_ok = $self->check_encrypted_zip_against_database();
+    $mets_ok = $self->check_decrypted_zip_against_mets();
+    if ($db_ok && $mets_ok) {
+      execute_stmt($update, "1", $self->{namespace}, $self->{objid}, $self->{version});
+    }
+    else {
+      execute_stmt($update, "0", $self->{namespace}, $self->{objid}, $self->{version});
+    }
+  };
+  if ($@) {
+    $self->set_error($self->{namespace}, $self->{objid}, 'CANT_ZIPCHECK', $@);
+  }
+  return ($db_ok && $mets_ok);
+}
+
+sub set_error {
+  my $self = shift;
+  my $namespace = shift;
+  my $objid = shift;
+  my $status = shift;
+  my $detail = shift || '';
+  # log error w/ l4p
+  my $logger = Log::Log4perl::get_logger( ref($self) );
+  $logger->error($status, $detail);
+  execute_stmt($insert_detail, $namespace, $objid, $self->{path},
+               $status, $detail);
+}
+
+sub execute_stmt {
+  my $stmt = shift;
+  my $dbh  = get_dbh();
+  my $sth  = $dbh->prepare($stmt);
+  $sth->execute(@_);
+  return $sth;
+}
+
+# Returns 1 if the encrypted zip file matches value in DB
+sub check_encrypted_zip_against_database {
+  my $self = shift;
+
+  my ($db_zipsum) = get_dbh()->selectrow_array($select_checksum, undef,
+                                               $self->{namespace},
+                                               $self->{objid},
+                                               $self->{version});
+  if (!defined $db_zipsum) {
+    die "No checksum in DB for $self->{namespace} $self->{objid} $self->{version}";
+  }
+  my $realsum = HTFeed::VolumeValidator::md5sum($self->{zip_path});
+  return 1 if $db_zipsum eq $realsum;
+
+  $self->set_error($self->{namespace}, $self->{objid}, 'BadChecksum',
+                   "expected=$db_zipsum actual=$realsum");
+  return 0;                       
+}
+
+sub check_decrypted_zip_against_mets {
+  my $self = shift;
+
+  my $mets = $self->{volume}->_parse_xpc($self->{mets_path});
+  my $storage = $self->{storage};
+  my $realsum = $storage->crypted_md5sum($self->{zip_path},
+                                         $storage->{config}{encryption_key});
+  my $ok = $storage->validate_zip_checksum($self->{mets_path},
+                                           "gpg --decrypt '$self->{zip_path}'",
+                                           $realsum);
+  unless ($ok) {
+    my @err = @{$storage->{errors}->[-1]};
+    my $status = shift @err;
+    my %detail = @err;
+    my $err = join ',', map { "$_=>$detail{$_}"; } keys %detail;
+    $self->set_error($self->{namespace}, $self->{objid}, $status, $err);
+  }
+  return $ok ? 1 : 0;
+}
+
+1;
+
+__END__

--- a/lib/HTFeed/Storage/S3.pm
+++ b/lib/HTFeed/Storage/S3.pm
@@ -103,6 +103,14 @@ sub get_object {
   return $self->s3api('get-object','--key',$key,@_,$dest);
 }
 
+sub restore_object {
+  my $self = shift;
+  my $bucket = shift;
+  my $key = shift;
+
+  return $self->s3api('restore-object','--key',$key,@_);
+}
+
 sub list_objects {
   my $self = shift;
 

--- a/t/glacier_zip_audit.t
+++ b/t/glacier_zip_audit.t
@@ -1,0 +1,171 @@
+use Test::Spec;
+use HTFeed::DBTools;
+use HTFeed::Storage::ObjectStore;
+use HTFeed::GlacierZipAudit;
+
+use strict;
+
+describe "HTFeed::GlacierZipAudit" => sub {
+  spec_helper 'storage_helper.pl';
+  spec_helper 's3_helper.pl';
+  local our ($tmpdirs, $testlog);
+  local our ($s3, $bucket);
+
+  sub HTFeed::Storage::S3::restore_object {
+    return 1;
+  }
+  
+  sub HTFeed::Storage::S3::head_object {
+    my $self = shift;
+    my $key = shift;
+    if ($ENV{S3_HEAD_OBJECT_RESTORE_PENDING}) {
+      return {Restore => 'ongoing-request="true"'};
+    }
+    elsif ($ENV{S3_HEAD_OBJECT_RESTORE_DONE}) {
+      return {Restore => 'ongoing-request="false"'};
+    }
+    return $self->s3api('head-object','--key',$key,@_);
+  }
+
+  sub object_storage {
+    my $volume = stage_volume($tmpdirs,@_);
+    
+    my $storage = HTFeed::Storage::ObjectStore->new(
+      volume => $volume,
+      config => {
+        bucket => $s3->{bucket},
+        awscli => $s3->{awscli},
+        encryption_key => $tmpdirs->test_home . "/fixtures/encryption_key"
+      },
+    );
+    $storage->encrypt;
+    $storage->move;
+    $storage->record_backup;
+    return $storage;
+  }
+
+  describe "choose" => sub {
+    it "succeeds" => sub {
+      my $storage = object_storage('test', 'test');
+      my $vol = HTFeed::GlacierZipAudit::choose('s3://bucket');
+      is($vol->{namespace}, 'test', 'choose returns namespace "test"');
+      is($vol->{objid}, 'test', 'choose returns objid "test"');
+      is($vol->{version}, $storage->{timestamp}, 'choose returns timestamp');
+      is($vol->{path}, "s3://$bucket/" . $storage->object_path(),
+         'choose returns object path');
+    };
+  };
+
+  describe "pending_objects" => sub {
+    it "succeeds" => sub {
+      #my $storage = object_storage('test', 'test');
+      my $auditable = HTFeed::GlacierZipAudit::pending_objects('s3://bucket');
+      is(scalar @$auditable, 0, 'pending_objects returns zero result');
+    };
+  };
+
+  describe "#new" => sub {
+    it "succeeds" => sub {
+      my $storage = object_storage('test', 'test');
+      my $audit = HTFeed::GlacierZipAudit->new(namespace => 'test', objid => 'test',
+                                               version => $storage->{timestamp},
+                                               s3 => $s3, bucket => $bucket,
+                                               storage => $storage);
+      ok($audit, 'new returns a value');
+    };
+  };
+  
+  describe "#submit_restore_object" => sub {
+    it "records restore_request for zip and METS" => sub {
+      my $storage = object_storage('test', 'test');
+      my $audit = HTFeed::GlacierZipAudit->new(namespace => 'test', objid => 'test',
+                                               version => $storage->{timestamp},
+                                               s3 => $s3, bucket => $bucket,
+                                               storage => $storage);
+      $audit->submit_restore_object();
+      my $sql = 'SELECT COUNT(*) FROM feed_backups' . 
+                ' WHERE namespace = ? AND id = ? AND version = ?' .
+                ' AND restore_request IS NOT NULL';
+      my @res = HTFeed::DBTools::get_dbh->selectrow_array($sql, undef,
+                                                          'test', 'test',
+                                                          $storage->{timestamp});
+      is($res[0], 1, 'restore_request count = 1');
+      my $auditable = HTFeed::GlacierZipAudit::pending_objects('s3://bucket');
+      is(scalar @$auditable, 1, 'pending_objects returns positive result');
+    };
+  };
+
+  describe "#run" => sub {
+    it "succeeds" => sub {
+      my $storage = object_storage('test', 'test');
+      $ENV{S3_HEAD_OBJECT_RESTORE_DONE} = 1;
+      my $audit = HTFeed::GlacierZipAudit->new(namespace => 'test', objid => 'test',
+                                               version => $storage->{timestamp},
+                                               s3 => $s3, bucket => $bucket,
+                                               storage => $storage);
+      my $result = $audit->run();
+      is($result, 1, 'succeeds');
+      delete $ENV{S3_HEAD_OBJECT_RESTORE_DONE};
+    };
+
+    it "removes restore_request when finished" => sub {
+      my $storage = object_storage('test', 'test');
+      $ENV{S3_HEAD_OBJECT_RESTORE_DONE} = 1;
+      my $audit = HTFeed::GlacierZipAudit->new(namespace => 'test', objid => 'test',
+                                               version => $storage->{timestamp},
+                                               s3 => $s3, bucket => $bucket,
+                                               storage => $storage);
+      my $result = $audit->run();
+      my $sql = 'SELECT COUNT(*) FROM feed_backups' . 
+                ' WHERE namespace = ? AND id = ? AND version = ?' .
+                ' AND restore_request IS NOT NULL';
+      my @res = HTFeed::DBTools::get_dbh->selectrow_array($sql, undef,
+                                                          'test', 'test',
+                                                          $storage->{timestamp});
+      is($res[0], 0, 'restore_request count = 0');
+      delete $ENV{S3_HEAD_OBJECT_RESTORE_DONE};
+    };
+
+    it "fails when METS checksum is altered" => sub {
+      my $storage = object_storage('test', 'test');
+      my $audit = HTFeed::GlacierZipAudit->new(namespace => 'test', objid => 'test',
+                                               version => $storage->{timestamp},
+                                               s3 => $s3, bucket => $bucket,
+                                               storage => $storage);
+      $audit->get_files();
+      `sed -i s/2d40d65c1aecd857b3f780e85bc9bd92/2d40d65c1aecd857b3f780e85bc9bd91/g $audit->{mets_path}`;
+      $ENV{S3_HEAD_OBJECT_RESTORE_DONE} = 1;
+      my $result = $audit->run();
+      is($result, 0, 'returns 0');
+      my $sql = 'SELECT COUNT(*) FROM feed_audit_detail' . 
+                ' WHERE namespace = ? AND id = ? AND status = "BadChecksum"';
+      my @res = HTFeed::DBTools::get_dbh->selectrow_array($sql, undef, 'test', 'test');
+      is($res[0], 1, 'BadChecksum error recorded');
+      delete $ENV{S3_HEAD_OBJECT_RESTORE_DONE};
+    };
+
+    it "fails when database checksum is altered" => sub {
+      my $storage = object_storage('test', 'test');
+      my $sql = 'UPDATE feed_backups SET saved_md5sum=?' .
+                ' WHERE namespace=? AND id=? AND version=?';
+      HTFeed::DBTools::get_dbh->prepare($sql)->execute('deadbeef' x 4,
+                                                       'test', 'test',
+                                                       $storage->{timestamp});
+      my $audit = HTFeed::GlacierZipAudit->new(namespace => 'test', objid => 'test',
+                                               version => $storage->{timestamp},
+                                               s3 => $s3, bucket => $bucket,
+                                               storage => $storage);
+      $ENV{S3_HEAD_OBJECT_RESTORE_DONE} = 1;
+      my $result = $audit->run();
+      is($result, 0, 'run returns 0');
+      $sql = 'SELECT COUNT(*) FROM feed_audit_detail' . 
+             ' WHERE namespace = ? AND id = ? AND status = "BadChecksum"';
+      my @res = HTFeed::DBTools::get_dbh->selectrow_array($sql, undef, 'test', 'test');
+      is($res[0], 1, 'BadChecksum error recorded');
+      delete $ENV{S3_HEAD_OBJECT_RESTORE_DONE};
+    };
+  };
+};
+
+runtests unless caller;
+

--- a/t/glacier_zip_audit.t
+++ b/t/glacier_zip_audit.t
@@ -76,7 +76,7 @@ describe "HTFeed::GlacierZipAudit" => sub {
   describe "choose" => sub {
     it "succeeds" => sub {
       my $storage = object_storage('test', 'test');
-      my $vol = HTFeed::GlacierZipAudit::choose('s3://bucket');
+      my $vol = HTFeed::GlacierZipAudit::choose('objectstore-test');
       is($vol->{namespace}, 'test', 'choose returns namespace "test"');
       is($vol->{objid}, 'test', 'choose returns objid "test"');
       is($vol->{version}, $storage->{timestamp}, 'choose returns timestamp');
@@ -89,7 +89,7 @@ describe "HTFeed::GlacierZipAudit" => sub {
 
   describe "pending_objects" => sub {
     it "succeeds" => sub {
-      my $auditable = HTFeed::GlacierZipAudit::pending_objects('s3://bucket');
+      my $auditable = HTFeed::GlacierZipAudit::pending_objects('objectstore-test');
       is(scalar @$auditable, 0, 'pending_objects returns zero result');
     };
   };
@@ -114,7 +114,7 @@ describe "HTFeed::GlacierZipAudit" => sub {
                                                           'test', 'test',
                                                           $storage->{timestamp});
       is($res[0], 1, 'restore_request count = 1');
-      my $auditable = HTFeed::GlacierZipAudit::pending_objects('s3://bucket');
+      my $auditable = HTFeed::GlacierZipAudit::pending_objects('objectstore-test');
       is(scalar @$auditable, 1, 'pending_objects returns positive result');
     };
   };


### PR DESCRIPTION
Notes:
1) Minio does not fully support `restore-object`/Glacier so there are some hacks in place in the testsuite.
2) As with the Data Den audit code, there is an "evil hack" note regarding storage config.
3) Added DB timestamp column is called `feed_backups.restore_request`