### PR TITLE
Change layout for versioned backups

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,18 @@ version: '3'
 
 services:
 
+  test:
+    build: .
+    volumes:
+      - .:/usr/local/feed
+    environment:
+      - HTFEED_CONFIG=/usr/local/feed/etc/config_test.yml
+      - FEED_HOME=/usr/local/feed
+      - TEST=1
+      - CLAMAV_HOST=clamav
+      - CLAMAV_PORT=3310
+    command: bin/wait-for --timeout=300 mariadb:3306 clamav:3310 -- make test TEST_VERBOSE=1
+
   ingest:
     build: .
     volumes:
@@ -16,18 +28,6 @@ services:
       - FEED_HOME=/usr/local/feed
       - CLAMAV_HOST=clamav
       - CLAMAV_PORT=3310
-
-  test:
-    build: .
-    volumes:
-      - .:/usr/local/feed
-    environment:
-      - HTFEED_CONFIG=/usr/local/feed/etc/config_test.yml
-      - FEED_HOME=/usr/local/feed
-      - TEST=1
-      - CLAMAV_HOST=clamav
-      - CLAMAV_PORT=3310
-    command: bin/wait-for --timeout=300 mariadb:3306 clamav:3310 -- make test TEST_VERBOSE=1
 
   validate:
     build: .

--- a/etc/config_ingest_docker.yml
+++ b/etc/config_ingest_docker.yml
@@ -26,7 +26,7 @@ storage_classes:
     link_dir: /sdr2/obj
     # The directory into which volumes will be loaded
     obj_dir: /sdr1/obj
-  - class: HTFeed::Storage::VersionedPairtree
+  - class: HTFeed::Storage::PrefixedVersions
     obj_dir: /htdataden
 
 jhove: /usr/bin/jhove

--- a/lib/HTFeed/Stage/Collate.pm
+++ b/lib/HTFeed/Stage/Collate.pm
@@ -10,7 +10,7 @@ use Carp qw(croak);
 
 use HTFeed::Storage::LocalPairtree;
 use HTFeed::Storage::LinkedPairtree;
-use HTFeed::Storage::VersionedPairtree;
+use HTFeed::Storage::PrefixedVersions;
 use HTFeed::Storage::ObjectStore;
 
 =head1 NAME

--- a/lib/HTFeed/Storage/ObjectStore.pm
+++ b/lib/HTFeed/Storage/ObjectStore.pm
@@ -118,7 +118,7 @@ sub postvalidate {
 
 sub move {
   my $self = shift;
-  $self->put_object($self->mets_key,$self->{volume}->get_mets_path());
+  $self->put_object($self->mets_key,$self->{mets_source});
   $self->put_object($self->zip_key,$self->{zip_source});
 }
 

--- a/t/collate.t
+++ b/t/collate.t
@@ -187,7 +187,7 @@ describe "HTFeed::Collate" => sub {
             link_dir => $tmpdirs->{link_dir}
           },
           {
-            class => 'HTFeed::Storage::VersionedPairtree',
+            class => 'HTFeed::Storage::PrefixedVersions',
             obj_dir => $tmpdirs->{backup_obj_dir},
             encryption_key => $tmpdirs->test_home . "/fixtures/encryption_key"
           },
@@ -223,8 +223,8 @@ describe "HTFeed::Collate" => sub {
         ok(-e "$tmpdirs->{obj_dir}/test/pairtree_root/te/st/test/test.mets.xml",'copies mets to local storage');
         ok(-e "$tmpdirs->{obj_dir}/test/pairtree_root/te/st/test/test.zip",'copies zip to local storage');
 
-        ok(-e "$tmpdirs->{backup_obj_dir}/test/pairtree_root/te/st/test/$timestamp/test.zip.gpg","copies the encrypted zip to backup storage");
-        ok(-e "$tmpdirs->{backup_obj_dir}/test/pairtree_root/te/st/test/$timestamp/test.mets.xml","copies the mets backup storage");
+        ok(-e "$tmpdirs->{backup_obj_dir}/test/tes/test.$timestamp.zip.gpg","copies the encrypted zip to backup storage");
+        ok(-e "$tmpdirs->{backup_obj_dir}/test/tes/test.$timestamp.mets.xml","copies the mets backup storage");
 
         my $s3_timestamp = $s3_backup->[0][0];
 

--- a/t/fixtures/DAMAGED/download/ia/test_ia_id/test_ia_id_files.xml
+++ b/t/fixtures/DAMAGED/download/ia/test_ia_id/test_ia_id_files.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files>
+  <file name="test_ia_id_djvu.xml">
+    <md5>8fe59a4eb6684b547bf0ae383707a451</md5>
+  </file>
+  <file name="test_ia_id_files.xml">
+    <md5>d41d8cd98f00b204e9800998ecf8427e</md5>
+  </file>
+  <file name="test_ia_id_jp2.zip">
+    <md5>76cdb2bad9582d23c1f6f4d868218d6c</md5>
+  </file>
+  <file name="test_ia_id_marc.xml">
+    <md5>49fcf4a32f9bc2dab22e84e2dc4efbf0</md5>
+  </file>
+  <file name="test_ia_id_meta.xml">
+    <md5>74945c0d689ce02d9d244f2f499eda63</md5>
+  </file>
+  <file name="test_ia_id_scandata.xml">
+    <md5>babed95372ddeb0575f19fe93beefd34</md5>
+  </file>
+</files>


### PR DESCRIPTION
- inode usage for pairtree in backup storage was too high (on average,
created several directories per actual file)

- New scheme: paths only one deep under namespace, named using a prefix of
the object ID of length max(3, length(objid-4)). This was empirically
determined to result in an mean directory size of around 80 objects,
median of 13, and maximum of around 30,000. We have been told that
performance should not suffer dramatically until we have hundreds of
thousands or millions of files in a single directory. This should result
in an overhead of only about 200,000 directories for ~34 million actual
files.

- This also eliminates the version directory and the individual object
directory

- Refactors Storage to add methods for determining the zip & METS
filename within the context of the storage rather than assuming they are
the same as the filenames of the original object