### PR TITLE
HT-3057: use s3 cp instead of s3api put-object

### DIFF
--- a/lib/HTFeed/Storage/ObjectStore.pm
+++ b/lib/HTFeed/Storage/ObjectStore.pm
@@ -136,23 +136,21 @@ sub postvalidate {
 
 sub move {
   my $self = shift;
-  $self->put_object($self->mets_key,$self->{mets_source});
-  $self->put_object($self->zip_key,$self->{zip_source});
+  $self->cp_to($self->{mets_source},$self->mets_key);
+  $self->cp_to($self->{zip_source},$self->zip_key);
 }
 
-sub put_object {
+sub cp_to {
   my $self = shift;
-  my $key = shift;
   my $source = shift;
+  my $key = shift;
 
   my $md5_base64 = $self->md5_base64($source);
 
   $self->{checksums}{$key} = $md5_base64;
   $self->{filesize}{$key} = -s $source;
 
-  $self->{s3}->put_object($key,
-    "--body",$source,
-    "--content-md5" => $md5_base64,
+  $self->{s3}->cp_to($source,$key,
     "--metadata" => "content-md5=" . $md5_base64);
 }
 

--- a/lib/HTFeed/Storage/S3.pm
+++ b/lib/HTFeed/Storage/S3.pm
@@ -24,6 +24,14 @@ sub cmd {
   return @{$self->{awscli}};
 }
 
+sub cp_to {
+  my $self = shift;
+  my $src = shift;
+  my $path = shift;
+
+  return $self->s3('cp',$src,"s3://$self->{bucket}/$path",@_);
+}
+
 sub mb {
   my $self = shift;
 
@@ -52,6 +60,8 @@ sub s3 {
   system(@fullcmd);
 
   die("awscli failed with status $?") if $?;
+
+  return 1;
 }
 
 sub s3api {
@@ -85,13 +95,6 @@ sub head_object {
   my $key = shift;
 
   return $self->s3api('head-object','--key',$key,@_);
-}
-
-sub put_object {
-  my $self = shift;
-  my $key = shift;
-
-  return $self->s3api('put-object','--key',$key,@_);
 }
 
 sub get_object {

--- a/t/s3_helper.pl
+++ b/t/s3_helper.pl
@@ -23,9 +23,9 @@ sub put_s3_files {
   print $tmpfh "test";
 
   foreach my $file (@_) {
-    $s3->s3api('put-object',
-      '--key',$file,
-      '--body',$tmpfh->filename);
+    $s3->s3('cp',
+      $tmpfh->filename,
+      "s3://$bucket/$file");
   }
 
   $tmpfh->close;

--- a/t/storage_audit.t
+++ b/t/storage_audit.t
@@ -48,8 +48,8 @@ describe "HTFeed::StorageAudit" => sub {
     $s3->rm('/',"--recursive");
     foreach my $n (0 .. 1) {
       my $storage = object_storage('test','test' . $n);
-      $storage->put_object($storage->mets_key,$storage->{volume}->get_mets_path());
-      $storage->put_object($storage->zip_key,$storage->zip_source);
+      $storage->cp_to($storage->{volume}->get_mets_path(), $storage->mets_key);
+      $storage->cp_to($storage->zip_source, $storage->zip_key);
       $storage->record_backup;
     }
   }


### PR DESCRIPTION
s3 cp automatically uses multi-part uploads and should generally have
better performance:
https://aws.amazon.com/premiumsupport/knowledge-center/s3-multipart-upload-cli/

One drawback is that we cannot specify the md5 checksum to validate
against with s3 cp:
https://aws.amazon.com/premiumsupport/knowledge-center/data-integrity-s3/

However, s3 cp will still calculate the checksum internally and compare
it before accepting the upload:
https://docs.aws.amazon.com/cli/latest/topic/s3-faq.html

There is potentially a race condition if the object is modified after we
compute the checksum but before s3 cp computes the checksum. We also
can't easily test/verify the documented behavior from our side the way
we can with the --checksum-md5 option to put-object. Ultimately, this
means we need a little bit more trust that aws cp does what the
documentation says. The other option (manually doing our own multi-part
uploads a la the multipart documentation above) seems even less
preferable.