### PR TITLE
HT-3127: cleanup for cron jobs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,25 +15,26 @@ RUN apt-get update && apt-get install -y \
 ARG UNAME=ingest
 ARG UID=1000
 ARG GID=1000
+ENV FEED_HOME=/usr/local/feed
 
 RUN groupadd -g $GID -o $UNAME
-RUN useradd -m -d /usr/local/feed -u $UID -g $GID -o -s /bin/bash $UNAME
+RUN useradd -m -d $FEED_HOME -u $UID -g $GID -o -s /bin/bash $UNAME
 
 USER $UID:$GID
 
 RUN mkdir -p /tmp/stage/grin
 RUN mkdir -p /tmp/prep/toingest /tmp/prep/failed /tmp/prep/ingested /tmp/prep/logs /tmp/prep/toingest/emma
 
-WORKDIR /usr/local/feed
+WORKDIR $FEED_HOME
 
-RUN mkdir /usr/local/feed/bin /usr/local/feed/src /usr/local/feed/.gnupg
-RUN chown $UID:$GID /usr/local/feed/.gnupg
-RUN chmod 700 /usr/local/feed/.gnupg
-COPY ./src/validateCache.cpp /usr/local/feed/src/validateCache.cpp
+RUN mkdir $FEED_HOME/bin $FEED_HOME/src $FEED_HOME/.gnupg
+RUN chown $UID:$GID $FEED_HOME/.gnupg
+RUN chmod 700 $FEED_HOME/.gnupg
+COPY ./src/validateCache.cpp $FEED_HOME/src/validateCache.cpp
 RUN /usr/bin/g++ -o bin/validateCache src/validateCache.cpp -lxerces-c
 
-COPY . /usr/local/feed
-COPY ./etc/sample_namespace/TEST.pm /usr/local/feed/etc/namespaces/TEST.pm
+COPY . $FEED_HOME
+COPY ./etc/sample_namespace/TEST.pm $FEED_HOME/etc/namespaces/TEST.pm
 
 ARG version=feed-development
 ENV VERSION=$version

--- a/Dockerfile.full
+++ b/Dockerfile.full
@@ -11,12 +11,12 @@ ARG UID=1001
 ARG GID=1001
 
 RUN groupadd -g $GID -o $UNAME
-RUN useradd -m -d /usr/local/feed -u $UID -g $GID -o -s /bin/bash $UNAME
-RUN chown -R $UID:$GID /tmp/prep /tmp/stage /usr/local/feed/.gnupg
+RUN useradd -m -d $FEED_HOME -u $UID -g $GID -o -s /bin/bash $UNAME
+RUN chown -R $UID:$GID /tmp/prep /tmp/stage $FEED_HOME/.gnupg
 USER $UID:$GID
 
-COPY ./bin/jobs  /usr/local/feed/bin/jobs
-COPY ./google    /usr/local/feed/google
-COPY ./lib/HTFeed/Namespace /usr/local/feed/lib/HTFeed/Namespace
+COPY ./bin/jobs  $FEED_HOME/bin/jobs
+COPY ./google    $FEED_HOME/google
+COPY ./lib/HTFeed/Namespace $FEED_HOME/lib/HTFeed/Namespace
 
-CMD ["/usr/bin/perl","-w","/usr/local/feed/bin/feed_single_thread.pl","-level","INFO","-screen","-dbi"]
+CMD ["/usr/bin/perl","-w","$FEED_HOME/bin/feed_single_thread.pl","-level","INFO","-screen","-dbi"]

--- a/Dockerfile.full
+++ b/Dockerfile.full
@@ -19,4 +19,4 @@ COPY ./bin/jobs  $FEED_HOME/bin/jobs
 COPY ./google    $FEED_HOME/google
 COPY ./lib/HTFeed/Namespace $FEED_HOME/lib/HTFeed/Namespace
 
-CMD ["/usr/bin/perl","-w","$FEED_HOME/bin/feed_single_thread.pl","-level","INFO","-screen","-dbi"]
+CMD ["/usr/bin/perl","-w","$FEED_HOME/bin/feed_single_thread.pl"]

--- a/bin/feed_single_thread.pl
+++ b/bin/feed_single_thread.pl
@@ -6,7 +6,7 @@ use strict;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 
-use HTFeed::Log { root_logger => 'INFO, dbi' };
+use HTFeed::Log { root_logger => 'INFO, dbi, screen' };
 use HTFeed::Version;
 
 use HTFeed::StagingSetup;


### PR DESCRIPTION
- Set `$FEED_HOME`
- Set default logging for `feed_single_thread.pl` in the script rather than passing it from the Dockerfile
- Update jobs submodule:
  - Don't move generated reports to duplicative archive space
  - revert "the hack" (https://github.com/hathitrust/feed_jobs/commit/926e1c57e1e0e80c4b3c36f1c179c1ae3dfeca43)
  - don't log to database for certain cron jobs