### PR TITLE
Add mysql client, msmtp, mailx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && apt-get install -y \
     libtest-mockobject-perl \
     libtest-most-perl \
     libtest-spec-perl \
+    mariadb-client \
     netcat
 
 ARG UNAME=ingest

--- a/Dockerfile.full
+++ b/Dockerfile.full
@@ -4,6 +4,10 @@ LABEL org.opencontainers.image.source https://github.com/hathitrust/feed
 
 USER root
 
+RUN apt-get update && apt-get install -y \
+    msmtp-mta \
+    bsd-mailx
+
 RUN bash -c 'for i in $(seq 1 24); do ln -s /sdr/$i /sdr$i; done'
 
 ARG UNAME=ingest-full


### PR DESCRIPTION
Allows sending mail from mysql + bash.

We should eventually change those scripts to just do queries in perl (or
at least use a separate docker image), but that's a later task.