### PR TITLE
HT-3209 Backup expiration logic is wrong

### DIFF
--- a/t/backup_expiration.t
+++ b/t/backup_expiration.t
@@ -119,38 +119,49 @@ describe "HTFeed::BackupExpiration" => sub {
       is($exp->{storage_name}, $vars{storage_name}, 'expiration has correct storage name');
     };
 
-    it "does not do anything with a single version" => sub {
+    it "does not do anything with a single old version" => sub {
       my $storage = prepare_storage($vars{storage_name}, old_random_timestamp());
       my $exp = HTFeed::BackupExpiration->new(storage_name => $vars{storage_name});
       $exp->run();
       my $deleted = count_deleted_objects('test', 'test', $storage->{timestamp});
       is($deleted, 0, 'object is not deleted');
-      ok(!mets_deleted($storage), "new ($storage->{timestamp}) mets left intact");
-      ok(!zip_deleted($storage), "new ($storage->{timestamp}) zip left intact");
+      ok(!mets_deleted($storage), "single ($storage->{timestamp}) mets left intact");
+      ok(!zip_deleted($storage), "single ($storage->{timestamp}) zip left intact");
     };
 
-    it "deletes old versions when there is a new one" => sub {
+    it "does not do anything with a single old version and single new one" => sub {
+      my $old_storage = prepare_storage($vars{storage_name}, old_random_timestamp());
+      my $new_storage = prepare_storage($vars{storage_name}, new_random_timestamp());
+      my $exp = HTFeed::BackupExpiration->new(storage_name => $vars{storage_name});
+      $exp->run();
+      my $deleted = count_deleted_objects('test', 'test', $old_storage->{timestamp});
+      is($deleted, 0, 'old object is not deleted');
+      ok(!mets_deleted($old_storage), "old ($old_storage->{timestamp}) mets left intact");
+      ok(!zip_deleted($old_storage), "old ($old_storage->{timestamp}) zip left intact");
+
+      $deleted = count_deleted_objects('test', 'test', $new_storage->{timestamp});
+      is($deleted, 0, 'new object is not deleted');
+      ok(!mets_deleted($new_storage), "new ($new_storage->{timestamp}) mets left intact");
+      ok(!zip_deleted($new_storage), "new ($new_storage->{timestamp}) zip left intact");
+    };
+
+    it "does not delete old versions when there is nothing new" => sub {
       my @old_versions;
       foreach my $n (1 .. 2) {
         my $storage = prepare_storage($vars{storage_name}, old_random_timestamp());
         push @old_versions, $storage;
       }
-      my $storage = prepare_storage($vars{storage_name}, new_random_timestamp());
       my $exp = HTFeed::BackupExpiration->new(storage_name => $vars{storage_name});
       $exp->run();
-      my $deleted = count_deleted_objects('test', 'test');
-      is($deleted, 2, 'two old objects marked with feed_backups.deleted=1');
-      $deleted = count_deleted_objects('test', 'test', $storage->{timestamp});
-      is($deleted, 0, 'newest object still feed_backups.deleted=0');
       foreach my $old_storage (@old_versions) {
-        ok(mets_deleted($old_storage), "old ($old_storage->{timestamp}) mets deleted");
-        ok(zip_deleted($old_storage), "old ($old_storage->{timestamp}) zip deleted");
+        my $deleted = count_deleted_objects('test', 'test', $old_storage->{timestamp});
+        is($deleted, 0, 'old object is not marked feed_backups.deleted');
+        ok(!mets_deleted($old_storage), "old ($old_storage->{timestamp}) mets left intact");
+        ok(!zip_deleted($old_storage), "old ($old_storage->{timestamp}) zip left intact");
       }
-      ok(!mets_deleted($storage), "new ($storage->{timestamp}) mets left intact");
-      ok(!zip_deleted($storage), "new ($storage->{timestamp}) zip left intact");
     };
 
-    it "keeps the newest old version" => sub {
+    it "deletes the oldest old version when there is a new one" => sub {
       my @old_versions;
       foreach my $n (1 .. 2) {
         my $storage = prepare_storage($vars{storage_name}, old_random_timestamp());
@@ -160,18 +171,19 @@ describe "HTFeed::BackupExpiration" => sub {
       if ($old_versions[0]->{timestamp} > $old_versions[1]->{timestamp}) {
         ($newer, $older) = @old_versions;
       }
+      my $storage = prepare_storage($vars{storage_name}, new_random_timestamp());
       my $exp = HTFeed::BackupExpiration->new(storage_name => $vars{storage_name});
       $exp->run();
-      my $sql = 'SELECT COUNT(*) FROM feed_backups' .
-                ' WHERE namespace=? AND id=? AND version=? AND deleted=1';
-      my @res = get_dbh->selectrow_array($sql, undef, 'test', 'test', $older->{timestamp});
-      is($res[0], 1, 'older object is marked feed_backups.deleted');
+      my $deleted = count_deleted_objects('test', 'test', $older->{timestamp});
+      is($deleted, 1, 'older object is marked feed_backups.deleted');
       ok(mets_deleted($older), "older ($older->{timestamp}) mets deleted");
       ok(zip_deleted($older), "older ($older->{timestamp}) zip deleted");
-      my $deleted = count_deleted_objects('test', 'test', $newer->{timestamp});
+      $deleted = count_deleted_objects('test', 'test', $newer->{timestamp});
       is($deleted, 0, 'newer object is not marked feed_backups.deleted');
       ok(!mets_deleted($newer), "newer ($newer->{timestamp}) mets left intact");
       ok(!zip_deleted($newer), "newer ($newer->{timestamp}) zip left intact");
+      ok(!mets_deleted($storage), "new ($storage->{timestamp}) mets left intact");
+      ok(!zip_deleted($storage), "new ($storage->{timestamp}) zip left intact");
     };
 
     it "keeps all new versions" => sub {


### PR DESCRIPTION
- First SQL query (clustering) makes sure there are both new and old versions.
- Second SQL query (deletion candidates) uses an offset=1 to preserve the most recent old version.
- Tests updated.