### PR TITLE
Workaround for memory leak in single thread runner

### DIFF
--- a/lib/HTFeed/Storage/S3.pm
+++ b/lib/HTFeed/Storage/S3.pm
@@ -29,7 +29,7 @@ sub cp_to {
   my $src = shift;
   my $path = shift;
 
-  return $self->s3('cp',$src,"s3://$self->{bucket}/$path",@_);
+  return $self->s3('cp','--only-show-errors',$src,"s3://$self->{bucket}/$path",@_);
 }
 
 sub mb {


### PR DESCRIPTION
- ensure we are waiting for the correct child before fetching another job
- get rid of messy output from awscli