### PR TITLE
HT-3183: Add dry-run flag for backup expiration

### DIFF
--- a/bin/expire_backups.pl
+++ b/bin/expire_backups.pl
@@ -6,16 +6,23 @@ use strict;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use HTFeed::Log { root_logger => 'INFO, screen' };
+use Getopt::Long qw(:config no_ignore_case);
+use Pod::Usage;
 use HTFeed::BackupExpiration;
 
-if (scalar @ARGV == 1) {
-  my $storage_name = $ARGV[0];
-  my $exp = HTFeed::BackupExpiration->new(storage_name => $storage_name);
-  $exp->run();
-} else {
-  print "Specify a feed_backups.storage_name value\n";
-  exit(0);
-}
+my $dry_run = 0; # -d
+my $storage_name = undef; # -s
+my $help = 0;
+
+GetOptions(
+  'dry-run|d' => \$dry_run,
+  'storage|s=s' => \$storage_name,
+  'help|?' => \$help
+) or pod2usage(2);
+pod2usage(1) if $help;
+
+my $exp = HTFeed::BackupExpiration->new(storage_name => $storage_name, dry_run => $dry_run);
+$exp->run();
 
 __END__
 
@@ -25,7 +32,7 @@ __END__
 
 =head1 SYNOPSIS
 
-expire_backups.pl STORAGE_NAME
+expire_backups.pl [--dry-run] -s STORAGE_NAME
     
     STORAGE_NAME - storage class name matched against feed_backups.storage_name
 


### PR DESCRIPTION
This is so we can verify what it would delete in production without actually deleting anything.