### PR TITLE
HT-3330: Support for testing FTPS in development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ ingest_stage/*
 ingest_sips/*
 .gnupg
 .bash_history
+var/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ LABEL org.opencontainers.image.source https://github.com/hathitrust/feed
 
 RUN apt-get update && apt-get install -y \
     awscli \
+    curl \
     epubcheck \
     libclamav-client-perl \
     libnet-prometheus-perl \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,11 +26,12 @@ services:
       - .:/usr/local/feed
       - ./ingest_sips:/tmp/sips
       - ./ingest_stage:/tmp/stage
+      - ~/.config/rclone/rclone.conf:/usr/local/feed/etc/rclone.conf
+      - ./etc/curlrc-development:/usr/local/feed/.curlrc
       # FIXME -- before these will work, run: docker-compose run --rm ingest chown ingest.ingest /sdr1 /sdr2 /htdataden
       - repository_link:/sdr1
       - repository_obj:/sdr2
       - backups:/htdataden
-      - ~/.config/rclone/rclone.conf:/usr/local/feed/etc/rclone.conf
     environment:
       - HTFEED_CONFIG=/usr/local/feed/etc/config_ingest_docker.yml
       - FEED_HOME=/usr/local/feed
@@ -86,6 +87,20 @@ services:
       - --web.enable-admin-api
     ports:
       - "9091:9091"
+
+  ftps:
+    image: stilliard/pure-ftpd
+    container_name: ftps
+    environment:
+      FTP_USER_NAME: ingest
+      FTP_USER_PASS: ingest
+      FTP_USER_HOME: /home/ingest
+      ADDED_FLAGS: "--tls=2"
+      TLS_CN: "ingest"
+      TLS_ORG: "HathiTrust"
+      TLS_C: "US"
+    volumes:
+      - ./var/zephir:/home/ingest
 
 volumes:
   repository_link:

--- a/etc/config_ingest_docker.yml
+++ b/etc/config_ingest_docker.yml
@@ -31,3 +31,9 @@ handle:
 rclone_config_path: /usr/local/feed/etc/rclone.conf
 
 pushgateway: http://pushgateway:9091
+
+zephir_ftps_server: ftps
+zephir_submissions_path: ""
+
+rights:
+  rights_dir: /usr/local/feed/var/rights

--- a/etc/curlrc-development
+++ b/etc/curlrc-development
@@ -1,0 +1,1 @@
+--insecure

--- a/etc/netrc
+++ b/etc/netrc
@@ -1,0 +1,1 @@
+machine ftps login ingest password ingest


### PR DESCRIPTION
- curl
- ftps server in docker-compose
- config for using ftps server

The curlrc automatically adds --insecure (-k) in development since we
only have a self-signed certificate.