### PR TITLE
HT-3375: run clamscan on demand

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ LABEL org.opencontainers.image.source https://github.com/hathitrust/feed
 
 RUN apt-get update && apt-get install -y \
     awscli \
+    clamav \
     curl \
     epubcheck \
     libclamav-client-perl \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,17 +6,15 @@ services:
     build: .
     volumes:
       - .:/usr/local/feed
+      - ./clamav:/var/lib/clamav
     environment:
       - HTFEED_CONFIG=/usr/local/feed/etc/config_test.yml
       - FEED_HOME=/usr/local/feed
       - TEST=1
-      - CLAMAV_HOST=clamav
-      - CLAMAV_PORT=3310
       - VERSION=feed-development
-    command: bin/wait-for --timeout=300 mariadb:3306 clamav:3310 minio:9000 pushgateway:9091 rabbitmq:5672 -- prove -I lib
+    command: bin/wait-for --timeout=300 mariadb:3306 minio:9000 pushgateway:9091 rabbitmq:5672 -- prove -I lib
     depends_on:
       - mariadb
-      - clamav
       - minio
       - pushgateway
       - rabbitmq
@@ -29,6 +27,7 @@ services:
       - ./ingest_stage:/tmp/stage
       - ~/.config/rclone/rclone.conf:/usr/local/feed/etc/rclone.conf
       - ./etc/curlrc-development:/usr/local/feed/.curlrc
+      - ./clamav:/var/lib/clamav
       # FIXME -- before these will work, run: docker-compose run --rm ingest chown ingest.ingest /sdr1 /sdr2 /htdataden
       - repository_link:/sdr1
       - repository_obj:/sdr2
@@ -39,12 +38,9 @@ services:
     environment:
       - HTFEED_CONFIG=/usr/local/feed/etc/config_ingest_docker.yml
       - FEED_HOME=/usr/local/feed
-      - CLAMAV_HOST=clamav
-      - CLAMAV_PORT=3310
       - VERSION=feed-development
     depends_on:
       - mariadb
-      - clamav
 
   validate:
     build: .
@@ -54,13 +50,10 @@ services:
     environment:
       - HTFEED_CONFIG=/usr/local/feed/etc/config_prevalidate.yml
       - FEED_HOME=/usr/local/feed
-      - CLAMAV_HOST=clamav
-      - CLAMAV_PORT=3310
       - VERSION=feed-development
     command: bash -c "/bin/ls /tmp/stage/toingest/test/*.zip | xargs -n 1 basename | sed s/.zip// | perl -w /usr/local/feed/bin/validate_volume.pl -p simple -n test --no-clean"
     depends_on:
       - mariadb
-      - clamav
 
   mariadb:
     build: docker/database
@@ -76,14 +69,6 @@ services:
       MINIO_ACCESS_KEY: TESTINGACCESSKEY
       MINIO_SECRET_KEY: testingsecretkey
     command: server /data
-
-  clamav:
-    image: clamav/clamav:stable
-    tty: true
-    restart: unless-stopped
-    volumes:
-      - ./ingest_sips:/tmp/sips
-      - ./ingest_stage:/tmp/stage
 
   pushgateway:
     image: prom/pushgateway

--- a/etc/config/premis.yml
+++ b/etc/config/premis.yml
@@ -25,7 +25,7 @@ premis_tools:
   KDU_COMPRESS: qq(kdu_compress 6.4.0)
   EPUBCHECK: qq(epubcheck 4.0.2)
   MP3VAL: qq(mp3val 0.1.8)
-  CLAMAV: qq(ClamAV 0.102.3)
+  CLAMAV: qq(ClamAV 0.103.5)
 
 # For each possible kind of PREMIS event, list the PREMIS eventType, the
 # eventDetail, the executor linkingAgent VOLUME_ARTIST), and any tool

--- a/etc/config_test.yml
+++ b/etc/config_test.yml
@@ -53,3 +53,4 @@ handle:
 
 use_dropbox: 0
 failure_limit: 5
+clamscan: /usr/bin/clamscan

--- a/lib/HTFeed/ClamScan.pm
+++ b/lib/HTFeed/ClamScan.pm
@@ -1,0 +1,41 @@
+package HTFeed::ClamScan;
+
+use strict;
+use HTFeed::Config qw(get_config);
+
+# Emulate ClamAV::Daemon interface, but run clamscan locally.
+
+sub new {
+  my $class = shift;
+
+  my $self = bless({},$class);
+  $self->{clamscan} = get_config('clamscan');
+  return $self;
+}
+
+sub ping {
+}
+
+sub scan_path {
+  my $self = shift;
+  my $path = shift;
+
+  my $clamscan = $self->{clamscan};
+  my $output = qx($clamscan "$path" 2>&1);
+  my $exitcode = $?;
+  my $result;
+
+  # couldn't run
+  if(defined $output and $exitcode == 0) {
+    # success
+    $result = undef;
+  } elsif(not defined $output) {
+    $result = "Couldn't run $clamscan; exit code $exitcode";
+  } else {
+    $result = "Virus found or error occurred (exit code $exitcode): $output";
+  }
+
+  return ($path, $result);
+}
+
+1;

--- a/t/emma.t
+++ b/t/emma.t
@@ -379,4 +379,38 @@ context "with volume & temporary ingest/preingest/zipfile dirs" => sub {
 
 };
 
+# To run these tests, first run
+# `docker-compose run test freshclam -l -`
+# (You may need to adjust permissions on ./clamav)
+if ( -e "/var/lib/clamav/main.cvd") { 
+  use HTFeed::ClamScan;
+
+  describe "HTFeed::ClamScan" => sub {
+    my $tmpdirs;
+
+    before all => sub {
+      $tmpdirs = HTFeed::Test::TempDirs->new();
+    };
+
+    it "can scan a file" => sub {
+      my $scanner = HTFeed::ClamScan->new();
+      my ($path, $result) = $scanner->scan_path($tmpdirs->test_home . "/fixtures/emma/test/emmatest.zip");
+      ok(not defined $result);
+      ok($path =~ qr(emmatest\.zip));
+    };
+
+    it "fails with a nonexistent file" => sub {
+      my $scanner = HTFeed::ClamScan->new();
+      my ($path, $result) = $scanner->scan_path('/tmp/nonexistent');
+      ok(defined $result);
+      ok($result =~ /Can't access file/m);
+      ok($path eq '/tmp/nonexistent');
+    };
+    
+  };
+} else {
+  warn("Skipping ClamAV tests; run freshclam first")
+}
+
+
 runtests unless caller;


### PR DESCRIPTION
Given the low number of files we need to scan (only items coming from
EMMA), running clamav in a sidecar container for every ingest worker is
a waste of resources; especially, downloading virus definitions for
every separate pod. This assumes virus definitions will be present at
/var/lib/clamav and calls out to clamscan when needed. It preserves the
same interface as ClamAV::Client, so switching back should be easy if
needed in the future.