### PR TITLE
Priority queue support

### DIFF
--- a/bin/enqueue.pl
+++ b/bin/enqueue.pl
@@ -21,6 +21,8 @@ my $reset_level = 0;
 my $insert = 0; # -i
 my $verbose = 0; # -v
 my $quiet = 0; # -q
+# Manually-queued stuff is at high priority by default
+my $priority = 3; # -p
 my $state = undef; # -s
 my $help = 0; # -help,-?
 my $use_disallow_list = 1;
@@ -44,6 +46,7 @@ GetOptions(
     'pkgtype|p=s' => \$default_packagetype,
     'namespace|n=s' => \$default_namespace,
     'use-disallow-list|b!' => \$use_disallow_list,
+    'priority|y=i' => \$priority,
 )  or pod2usage(2);
 
 # highest level wins
@@ -119,11 +122,11 @@ my $queue = HTFeed::Queue->new();
 
 foreach my $volume (@volumes) {
   if(!($reset_level) or $insert) {
-    print_result('queued',$volume,$queue->enqueue(volume=>$volume,status=>$state,ignore=>$insert,use_disallow_list=>$use_disallow_list));
+    print_result('queued',$volume,$queue->enqueue(volume=>$volume,status=>$state,ignore=>$insert,priority=>$priority,use_disallow_list=>$use_disallow_list));
   }
 
   if($reset_level){
-    print_result('reset',$volume,$queue->reset(volume => $volume, status => $state, reset_level => $reset_level));
+    print_result('reset',$volume,$queue->reset(volume => $volume, status => $state, priority=>$priority, reset_level => $reset_level));
       
   }
 }
@@ -188,6 +191,8 @@ enqueue.pl [-v|-q] [-r|-R|-i] -1 packagetype namespace objid
     -q quiet - skip report
     
     -s state - set initial state to state (e.g. ready, available, etc)
+
+    -y priority - set priority; 3 is high priority, 2 is medium priority, 1 is low priority
 
     --no-use-disallow-list - ignore the disallow list and force enqueueing of the given volumes
 

--- a/etc/config_test.yml
+++ b/etc/config_test.yml
@@ -32,6 +32,7 @@ rabbitmq:
   user: guest
   password: guest
   queue: testqueue
+  priority_levels: 3
 
 use_rabbitmq: 1
 

--- a/lib/HTFeed/Bunnies.pm
+++ b/lib/HTFeed/Bunnies.pm
@@ -1,4 +1,5 @@
 use utf8;
+use strict;
 package HTFeed::Bunnies;
 
 use Net::AMQP::RabbitMQ;
@@ -39,7 +40,7 @@ sub connect {
 
   my $queue_arguments = {};
   if($self->{priority_levels} > 1) {
-    $queue_arguments->{"x-max-priority"} = $self->{priority_levels};
+    $queue_arguments->{"x-max-priority"} = int($self->{priority_levels});
   }
 
   $mq->connect($self->{host}, { user => $self->{user}, password => $self->{password} });

--- a/lib/HTFeed/Bunnies.pm
+++ b/lib/HTFeed/Bunnies.pm
@@ -17,11 +17,12 @@ sub new {
   my %params = @_;
 
   my $self = {
-    channel     => $params{channel}  || $AMQP_DEFAULT_CHANNEL,
-    host        => $params{host}     || get_config('rabbitmq','host'),
-    user        => $params{user}     || get_config('rabbitmq','user'),
-    password    => $params{password} || get_config('rabbitmq','password'),
-    queue       => $params{queue}    || get_config('rabbitmq','queue'),
+    channel          => $params{channel}         || $AMQP_DEFAULT_CHANNEL,
+    host             => $params{host}            || get_config('rabbitmq','host'),
+    user             => $params{user}            || get_config('rabbitmq','user'),
+    password         => $params{password}        || get_config('rabbitmq','password'),
+    queue            => $params{queue}           || get_config('rabbitmq','queue'),
+    priority_levels  => $params{priority_levels} || get_config('rabbitmq','priority_levels'),
     consumer_started => 0,
   };
   bless($self, $class);
@@ -36,9 +37,14 @@ sub connect {
 
   my $mq = Net::AMQP::RabbitMQ->new();
 
+  my $queue_arguments = {};
+  if($self->{priority_levels} > 1) {
+    $queue_arguments->{"x-max-priority"} = $self->{priority_levels};
+  }
+
   $mq->connect($self->{host}, { user => $self->{user}, password => $self->{password} });
   $mq->channel_open($self->{channel});
-  $mq->queue_declare($self->{channel}, $self->{queue}, { durable => 1, auto_delete => 0});
+  $mq->queue_declare($self->{channel}, $self->{queue}, { durable => 1, auto_delete => 0}, $queue_arguments);
   get_logger()->debug("$BUNNY: connected to $self->{host} on channel $self->{channel} using queue $self->{queue}");
 
   $self->{mq} = $mq;
@@ -49,13 +55,20 @@ sub queue_job {
 
   my %job_params = @_;
 
+  my $props = { delivery_mode => $AMQP_DELIVERY_PERSISTENT };
+  
+  if($job_params{priority}) {
+    $props->{priority} = $job_params{priority};
+    delete $job_params{priority};
+  }
+
   my $msg = encode_json(\%job_params);
 
   my $rval = $self->{mq}->publish($self->{channel},
     $self->{queue},
     $msg,
     {},
-    { delivery_mode => $AMQP_DELIVERY_PERSISTENT }
+    $props,
   );
 
   get_logger()->debug("$BUNNY: published message on channel $self->{channel} to queue $self->{queue}");

--- a/t/queue.t
+++ b/t/queue.t
@@ -78,6 +78,13 @@ describe "HTFeed::Queue" => sub {
 
         test_job_queued_for_volume(testvolume, 'ready');
       };
+
+      it "accepts a priority" => sub {
+        HTFeed::Queue->new->enqueue(volume => testvolume, status => 'ready', priority => 3);
+        my $job = HTFeed::Bunnies->new()->next_job($NO_WAIT);
+
+        is($job->{msg}{props}{priority}, 3);
+      }
     };
 
     describe "with an item already in the queue" => sub {
@@ -236,6 +243,15 @@ describe "HTFeed::Queue" => sub {
         $queue->enqueue(volume=>testvolume, status=>'punted');
         $queue->reset(volume=>testvolume, reset_level => 1);
         ok(volume_in_feed_queue(testvolume, 'ready'));
+      };
+
+      it "accepts a priority" => sub {
+        my $queue = HTFeed::Queue->new;
+        $queue->enqueue(volume=>testvolume, status=>'punted');
+        $queue->reset(volume=>testvolume, reset_level => 1, priority => 3);
+
+        my $job = HTFeed::Bunnies->new()->next_job($NO_WAIT);
+        is($job->{msg}{props}{priority}, 3);
       };
 
       it "re-queues a message for a punted volume" => sub {


### PR DESCRIPTION
This will enable us to queue e.g. items from the command line at high priority while keeping re-ingest at lower priority.