### PR TITLE
DEV-225: Preserve priority from database to rabbitmq

### DIFF
--- a/bin/enqueue.pl
+++ b/bin/enqueue.pl
@@ -22,7 +22,7 @@ my $insert = 0; # -i
 my $verbose = 0; # -v
 my $quiet = 0; # -q
 # Manually-queued stuff is at high priority by default
-my $priority = 3; # -p
+my $priority = HTFeed::Queue::QUEUE_PRIORITY_HIGH; # -p
 my $state = undef; # -s
 my $help = 0; # -help,-?
 my $use_disallow_list = 1;

--- a/lib/HTFeed/Queue.pm
+++ b/lib/HTFeed/Queue.pm
@@ -14,7 +14,7 @@ use HTFeed::Bunnies;
 
 use Log::Log4perl qw(get_logger);
 
-our @EXPORT = qw(enqueues reset QUEUE_PRIORITY_HIGH QUEUE_PRIORITY_MED QUEUE_PRIORITY_LOW);
+our @EXPORT = qw(enqueue reset QUEUE_PRIORITY_HIGH QUEUE_PRIORITY_MED QUEUE_PRIORITY_LOW);
 
 use constant QUEUE_PRIORITY_HIGH => 3;
 use constant QUEUE_PRIORITY_MED => 2;


### PR DESCRIPTION
- Records the priority when queued in the (existing) priority column in
feed_queue

- Passes this priority along to rabbitmq when resetting the item