### PR TITLE
DEV-332 CRMS .rights Files Need to be UTF-8

### DIFF
--- a/lib/HTFeed/DBTools.pm
+++ b/lib/HTFeed/DBTools.pm
@@ -36,7 +36,8 @@ sub _init {
     my $passwd = get_config('database','password');
 
     $dbh = DBI->connect($dsn, $user, $passwd,
-    {'RaiseError' => 1});
+    {'RaiseError' => 1, 'mysql_enable_utf8=1' => 1});
+    $dbh->do('SET NAMES "utf8";');
 
     $pid = $$;
 

--- a/t/db.t
+++ b/t/db.t
@@ -2,6 +2,8 @@
 
 use strict;
 use warnings;
+use utf8;
+use Encode qw(encode);
 use HTFeed::DBTools qw(get_dbh);
 use Test::More;
 
@@ -62,6 +64,34 @@ eval{
 	$execute = $sth->execute;
 };
 ok($execute, "correct syntax");
+
+subtest "UTF-8 support for ht_rights" => sub {
+  my @tables = ('rights_current', 'rights_log');
+  foreach my $table (@tables) {
+    clean_utf8_test($table);
+    my $sql = "INSERT INTO $table (namespace,id,attr,reason,source,access_profile,user,note)" .
+              " VALUES ('utf8test','0',2,1,1,1,'libadm','慶應義塾大')";
+    my $sth = $dbh->prepare($sql);
+    $sth->execute;
+    $sth = $dbh->prepare("SELECT note FROM $table WHERE namespace=? AND id=?");
+    $sth->execute('utf8test', '0');
+    my @row = $sth->fetchrow_array;
+    $sth->finish;
+    is($row[0], encode('UTF-8', "慶應義塾大"), "UTF-8 round-trip in $table.note");
+    $sth = $dbh->prepare("SELECT COUNT(*) FROM $table WHERE note='慶應義塾大'");
+    $sth->execute;
+    @row = $sth->fetchrow_array;
+    is($row[0], 1, "Can find $table.note with UTF-8 value.");
+    clean_utf8_test($table);
+  }
+
+  sub clean_utf8_test {
+    my $table = shift;
+
+    my $sth = $dbh->prepare("DELETE FROM $table WHERE namespace=? AND id=?");
+    $sth->execute('utf8test', '0');
+  }
+};
 
 done_testing();
 


### PR DESCRIPTION
- This patch may be necessary in order to get UTF-8 data into the rights DB.
- However, the added tests pass regardless of the changes to DBTools.pm.
- If the feed_internal populate_rights_data.pl script fails with Unicode text, consider this patch.