### PR TITLE
TTO-14 Remove digitizer check by default

### DIFF
--- a/bin/ingest_nohandle.pl
+++ b/bin/ingest_nohandle.pl
@@ -60,11 +60,6 @@ if ($fakemeta) {
     return ( 'ht_test','ht_test','ht_test' );
   };
 
-  # don't validate digitizer -- will fail against faked up sources
-  *HTFeed::VolumeValidator::_validate_digitizer = sub {
-    return 1;
-  };
-
   # use faked-up marc in case it's missing
 
   *HTFeed::SourceMETS::_get_marc_from_zephir = sub {

--- a/bin/validate_bentleyaudio_chipmunk.pl
+++ b/bin/validate_bentleyaudio_chipmunk.pl
@@ -31,7 +31,6 @@ unless( $dir ){
 my $volume =  HTFeed::TestVolume->new(packagetype => $packagetype, namespace => $namespace, dir => $dir, objid => $objid);
 
 my $vol_val = HTFeed::PackageType::BentleyAudio::VolumeValidator->new(volume => $volume);
-@{$vol_val->{run_stages}} = grep { $_ ne 'validate_digitizer' } @{$vol_val->{run_stages}};
 
 $vol_val->run();
 

--- a/bin/validate_vendoraudio_chipmunk.pl
+++ b/bin/validate_vendoraudio_chipmunk.pl
@@ -31,7 +31,6 @@ unless( $dir ){
 my $volume =  HTFeed::TestVolume->new(packagetype => $packagetype, namespace => $namespace, dir => $dir, objid => $objid);
 
 my $vol_val = HTFeed::PackageType::Audio::VolumeValidator->new(volume => $volume);
-@{$vol_val->{run_stages}} = grep { $_ ne 'validate_digitizer' } @{$vol_val->{run_stages}};
 
 $vol_val->run();
 

--- a/bin/validate_volume.pl
+++ b/bin/validate_volume.pl
@@ -60,11 +60,6 @@ unless ($realmeta) {
     return ( 'ht_test','ht_test','ht_test' );
   };
 
-  # don't validate digitizer -- will fail against faked up sources
-  *HTFeed::VolumeValidator::_validate_digitizer = sub {
-    return 1;
-  };
-
   # use faked-up marc in case it's missing
 
   *HTFeed::SourceMETS::_get_marc_from_zephir = sub {

--- a/lib/HTFeed/PackageType.pm
+++ b/lib/HTFeed/PackageType.pm
@@ -66,8 +66,7 @@ BEGIN {
               validate_consistency
               validate_checksums
               validate_utf8
-              validate_metadata
-              validate_digitizer)
+              validate_metadata)
         ],
 
         premis_overrides => {

--- a/lib/HTFeed/PackageType/DLXS_novalidate.pm
+++ b/lib/HTFeed/PackageType/DLXS_novalidate.pm
@@ -33,8 +33,7 @@ our $config = {
           validate_filegroups_nonempty
           validate_checksums
           validate_utf8
-          validate_metadata
-          validate_digitizer)
+          validate_metadata)
     ],
 
     skip_validation => [

--- a/lib/HTFeed/PackageType/EPUB.pm
+++ b/lib/HTFeed/PackageType/EPUB.pm
@@ -100,8 +100,7 @@ our $config = {
       validate_checksums
       validate_utf8
       validate_metadata
-      validate_epub
-      validate_digitizer)
+      validate_epub)
     ],
 
     # What PREMIS events to include in the source METS file

--- a/lib/HTFeed/PackageType/IA.pm
+++ b/lib/HTFeed/PackageType/IA.pm
@@ -66,8 +66,7 @@ our $config = {
     validate_filegroups_nonempty 
     validate_checksums
     validate_utf8                
-    validate_metadata
-    validate_digitizer)
+    validate_metadata)
     ],
 
     # What PREMIS events to include in the source METS file

--- a/lib/HTFeed/PackageType/MDLContone.pm
+++ b/lib/HTFeed/PackageType/MDLContone.pm
@@ -53,8 +53,7 @@ our $config = {
     validate_filegroups_nonempty
     validate_checksums
     validate_utf8
-    validate_metadata
-    validate_digitizer)
+    validate_metadata)
     ],
 
     # what stage to run given the current state

--- a/lib/HTFeed/PackageType/MDLContone_Composite.pm
+++ b/lib/HTFeed/PackageType/MDLContone_Composite.pm
@@ -53,8 +53,7 @@ our $config = {
     validate_filegroups_nonempty
     validate_checksums
     validate_utf8
-    validate_metadata
-    validate_digitizer)
+    validate_metadata)
     ],
 
     # what stage to run given the current state

--- a/lib/HTFeed/VolumeValidator.pm
+++ b/lib/HTFeed/VolumeValidator.pm
@@ -32,7 +32,6 @@ sub new {
     validate_checksums           => \&_validate_checksums,
     validate_utf8                => \&_validate_utf8,
     validate_metadata            => \&_validate_metadata,
-    validate_digitizer => \&_validate_digitizer
   };
 
   return $self;
@@ -321,27 +320,6 @@ sub _validate_metadata {
   return;
 }
 
-sub _validate_digitizer {
-  my $self = shift;
-  my $volume = $self->{volume};
-
-  my (undef,undef,$zephir_dig_agents) = $volume->get_sources();
-  my $apparent_digitizer = $volume->apparent_digitizer();
-
-  return 1 if (not defined $zephir_dig_agents or $zephir_dig_agents eq '') and 
-  (not defined $apparent_digitizer or $apparent_digitizer eq '');
-
-  my @allowed_agents = split(';',$zephir_dig_agents);
-
-  # apparent digitizer must match one of the agent IDs the zephir dig. source maps to
-  foreach my $allowed_agent (@allowed_agents) {
-    $allowed_agent =~ s/\*$//;
-    return 1 if $allowed_agent eq $apparent_digitizer;
-  }
-
-  $self->set_error("BadValue",field => "digitizer",expected => "$zephir_dig_agents",actual=> $apparent_digitizer,detail=>"apparent digitizer does not match expected digitizer from zephir");
-}
-
 sub md5sum {
   my $file = shift;
   my $ctx  = Digest::MD5->new();
@@ -413,11 +391,6 @@ valid UTF8 and does not contain any control characters other than tab and CR.
 * _validate_metadata()
 
 Runs JHOVE on all the files for the given volume and validates their metadata.
-
-* _validate_digitizer()
-
-Validate that the apparent digitization agent (from source METS, image metadata, etc, as 
-determined by package type) matches the expected digitization agent from Zephir.
 
 =item stage_info()
 


### PR DESCRIPTION
This was relying on hacks in several package types to determine the apparent digitizer, and it's better to check specifically what we can in each package type where it matters.