### PR TITLE
GS-5046: JPEG2000 images can have any (reasonable) number of layers

### DIFF
--- a/lib/HTFeed/PackageType/Simple.pm
+++ b/lib/HTFeed/PackageType/Simple.pm
@@ -136,7 +136,7 @@ our $config = {
         'HTFeed::ModuleValidator::JPEG2000_hul' => {
             'camera' => undef,
             # allow most common # of layers
-          'layers' => v_in( 'codingStyleDefault', 'layers', ['1','6','8','25'] ),
+          'layers' => v_between( 'codingStyleDefault', 'layers', '1','25' ),
           'decomposition_levels' => v_between( 'codingStyleDefault', 'decompositionLevels', '1', '32'),
           'resolution'      => v_and(
               v_ge( 'xmp', 'xRes', 300 ), # should work even though resolution is specified as NNN/1


### PR DESCRIPTION
There isn't any particular reason that we know of to enforce a particular number of layers. We have seen a variety over the years; in the particular instance that inspired this change, there were 3. Rather than enumerating another possible option for something that isn't terribly important, this change just allows any value in the range we've seen.

A consistent number of layers is probably more important for Google-scanned material, where a change in the number of layers could reflect some other change in their image compression process, but I don't think it should matter here for locally-digitized material.