### PR TITLE
Don't restore deleted objects

### DIFF
--- a/lib/HTFeed/StorageAudit/ObjectStore.pm
+++ b/lib/HTFeed/StorageAudit/ObjectStore.pm
@@ -60,7 +60,7 @@ sub objects_to_audit {
   $self->_request_object($self->random_object());
   my $sql = 'SELECT namespace,id,version,path FROM feed_backups' .
             ' WHERE storage_name=?' .
-            ' AND restore_request IS NOT NULL';
+            ' AND deleted IS NULL and restore_request IS NOT NULL';
   $self->{pending_objects} = [];
   eval {
     my $ref = get_dbh->selectall_arrayref($sql, undef, $self->{storage_name});


### PR DESCRIPTION
This works around a race condition where we issue a restore request, but the object has been deleted before the restore request & audit completes successfully.