### PR TITLE
TTO-118: flag to reuse failed item

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 volumes_to_test
 ingest_stage
 ingest_sips
+incoming_samples

--- a/etc/config_ingest_docker.yml
+++ b/etc/config_ingest_docker.yml
@@ -33,6 +33,7 @@ rabbitmq:
   user: guest
   password: guest
   queue: ingest
+  priority_levels: 3
 
 volumes_in_process_limit: 1
 

--- a/etc/config_test.yml
+++ b/etc/config_test.yml
@@ -34,8 +34,6 @@ rabbitmq:
   queue: testqueue
   priority_levels: 3
 
-use_rabbitmq: 1
-
 test_awscli: ['aws', '--endpoint-url', 'http://minio:9000']
 
 pushgateway: http://pushgateway:9091

--- a/lib/HTFeed/PackageType/Simple/Unpack.pm
+++ b/lib/HTFeed/PackageType/Simple/Unpack.pm
@@ -22,11 +22,6 @@ sub run {
 
   my $file = $volume->get_sip_location();
 
-  # for retrying
-  if(not -e $file) {
-    $file = $volume->get_failure_sip_location();
-  }
-
   if(-e $file) {
     $self->unzip_file($file,$dest);
     $self->_set_done();

--- a/lib/HTFeed/Queue.pm
+++ b/lib/HTFeed/Queue.pm
@@ -243,8 +243,6 @@ sub send_to_message_queue {
   my $status = shift;
   my $priority = shift;
 
-  # feature gate
-  return unless get_config('use_rabbitmq');
   return if grep { $_ eq $status } @{get_config('release_states')};
 
   my $q = $self->message_queue;


### PR DESCRIPTION
Rather than try to encode logic about when it does or doesn't re-download vs. re-use what we already have that varies based on whether the contributor is using dropbox or not, this makes it explicit when re-queuing something whether to use what's already been downloaded or not.

This also removes the logic that (sometimes but only in very specific circumstances/configurations now that we usually check dropbox) tries to automatically re-attempt what's in /htprep/failed, and removes a feature gate that we no longer need (now that all configurations use rabbitmq)