### PR TITLE
Install validate-cache in /usr/local/bin

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@ volumes_to_test
 ingest_stage
 ingest_sips
 incoming_samples
+.gnupg

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,6 +75,9 @@ RUN mkdir /extlib
 RUN chown $UID:$GID /extlib
 ENV PERL5LIB="/extlib/lib/perl5:$FEED_HOME/lib"
 
+COPY ./src/validateCache.cpp /usr/src/validateCache.cpp
+RUN /usr/bin/g++ -o /usr/local/bin/validate-cache /usr/src/validateCache.cpp -lxerces-c
+
 USER $UID:$GID
 
 WORKDIR $FEED_HOME
@@ -93,8 +96,6 @@ RUN mkdir -p /tmp/prep/toingest /tmp/prep/failed /tmp/prep/ingested /tmp/prep/lo
 RUN mkdir $FEED_HOME/bin $FEED_HOME/src $FEED_HOME/.gnupg
 RUN chown $UID:$GID $FEED_HOME/.gnupg
 RUN chmod 700 $FEED_HOME/.gnupg
-COPY ./src/validateCache.cpp $FEED_HOME/src/validateCache.cpp
-RUN /usr/bin/g++ -o bin/validateCache src/validateCache.cpp -lxerces-c
 
 COPY . $FEED_HOME
 

--- a/etc/config/base_config.yml
+++ b/etc/config/base_config.yml
@@ -91,7 +91,7 @@ gpg_path: /usr/local/feed/etc/gpg
 imagemagick: /usr/bin/convert
 jhove: /opt/jhove/jhove
 jhoveconf: /opt/jhove/conf/jhove.conf
-xerces: /usr/local/feed/bin/validateCache
+xerces: /usr/local/bin/validate-cache
 xerces_cache: /usr/local/feed/etc/schema.cache
 grk_compress: /usr/bin/grk_compress
 grk_decompress: /usr/bin/grk_decompress


### PR DESCRIPTION
This should solve an issue with running tests locally without building validate-cache separately.

Also adds .gnupg to dockerignore to prevent gnupg junk from ending up inside the image (not sure if this was an issue or not, but we wouldn't want it anyway)