### PR TITLE
Getting feed repo working, shameless green, for mwarin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Build docker image
-        run: docker-compose --file docker-compose.test.yml build
+        run: docker compose --file docker-compose.test.yml build
 
       - name: Run tests
-        run: docker-compose --file docker-compose.test.yml run sut
+        run: docker compose --file docker-compose.test.yml run sut
         env:
           GITHUB_TOKEN: ${{ secrets.github_token }}

--- a/README.md
+++ b/README.md
@@ -6,24 +6,24 @@ HathiTrust Ingest Toolkit
 ```bash
 git clone https://github.com/hathitrust/feed
 cd ingest
-docker-compose build
+docker compose build
 ```
 
 # Development
 
 Running tests:
 ```
-docker-compose run test 
+docker compose run test
 ```
 
 Running specific tests and/or getting prettier output:
 ```
 # Runs all tests
-docker-compose run test prove
+docker compose run test prove
 # Run a specific set of tests
-docker-compose run test prove t/storage.t
+docker compose run test prove t/storage.t
 # Get more verbose output from a specific test
-docker-compose run test perl t/storage.t
+docker compose run test perl t/storage.t
 ```
 
 ## Validating volumes
@@ -31,7 +31,7 @@ docker-compose run test perl t/storage.t
 * Put volumes in `volumes_to_test/`
 
 ```bash
-docker-compose run validate
+docker compose run validate
 ```
 
 ## Validating a single image
@@ -63,7 +63,7 @@ zip test_volume.zip 00000001.* checksum.md5 meta.yml
 
 * Put the file in `volumes_to_test/`
 
-* Run `docker-compose run validate`
+* Run `docker compose run validate`
 
 ## Testing with RClone
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - ./ingest_stage:/tmp/stage
       - ~/.config/rclone/rclone.conf:/usr/local/feed/etc/rclone.conf
       - ./clamav:/var/lib/clamav
-      # FIXME -- before these will work, run: docker-compose run --rm ingest chown ingest.ingest /sdr1 /sdr2 /htdataden
+      # FIXME -- before these will work, run: docker compose run --rm ingest chown ingest.ingest /sdr1 /sdr2 /htdataden
       - repository_link:/sdr1
       - repository_obj:/sdr2
       - backups:/htdataden

--- a/t/emma.t
+++ b/t/emma.t
@@ -380,7 +380,7 @@ context "with volume & temporary ingest/preingest/zipfile dirs" => sub {
 };
 
 # To run these tests, first run
-# `docker-compose run test freshclam -l -`
+# `docker compose run test freshclam -l -`
 # (You may need to adjust permissions on ./clamav)
 if ( -e "/var/lib/clamav/main.cvd") { 
   use HTFeed::ClamScan;

--- a/t/lib/HTFeed/Test/SpecSupport.pm
+++ b/t/lib/HTFeed/Test/SpecSupport.pm
@@ -16,7 +16,7 @@ use Exporter 'import';
 our @EXPORT_OK = qw(mock_zephir mock_clamav stage_volume);
 
 sub mock_zephir {
-
+  no warnings 'redefine';
   *HTFeed::Volume::get_sources = sub {
     return ( 'ht_test','ht_test','ht_test' );
   };
@@ -42,6 +42,7 @@ EOT
 
   };
 
+  use warnings 'redefine';
 }
 
 sub mock_clamav {

--- a/t/storage_audit.t
+++ b/t/storage_audit.t
@@ -99,6 +99,9 @@ describe "HTFeed::StorageAudit" => sub {
     }
   }
 
+  no warnings 'redefine';
+  # These next subs may redefine existing subs,
+  # suppressing warnings.
   sub HTFeed::Storage::S3::restore_object {
     return 1;
   }
@@ -120,6 +123,7 @@ describe "HTFeed::StorageAudit" => sub {
 
     return HTFeed::StorageAudit->for_storage_name($self->{name});
   }
+  use warnings 'redefine';
 
   share my %vars;
   shared_examples_for "all storages" => sub {


### PR DESCRIPTION
Mission: to get the `feed` repo to a clean state where @mwarin can start working with it.

Turns out we didn't need to do a lot more to get it working, it was mostly a case of a really old docker installation locally. Tests are coming up green both locally and under github actions. Some things (issues with `xerces` & `gnupg`) were fixed by @aelkiss in https://github.com/hathitrust/feed/commit/8b4115dcd92cde5fefb28dd7d1eb99f7fe976c19.

Also had to mess around with my ssh keys so I could start using the ssh protocol, because you are no longer allowed to push to workflows with https for some (security?) reason. That's not in the PR either.

## Actual changes

Changing `docker-compose` to hyphenless `docker compose` and removing a few warnings from the tests.

## To review

(You may have to stop or prune existing services.)

```
cd /tmp
git clone -b validate-cache-usr-local git@github.com:hathitrust/feed ./feed_clean
cd /tmp/feed_clean
docker build
docker compose run test
```

## Expected results: 

It'll take several minutes to build and test.

Expect to see some warnings, but ultimately a message that tests passed:
`Result: PASS`