### PR TITLE
DEV-1075: add HTFeed::JobMetrics

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,8 +60,6 @@ RUN echo "deb [signed-by=/usr/share/keyrings/hathitrust-archive-keyring.gpg] htt
 
 RUN apt-get update && apt-get install -y grokj2k-tools
 
-RUN cpan -f -i Net::AMQP::RabbitMQ
-
 COPY etc/imagemagick-policy.xml /etc/ImageMagick-6/policy.xml
 
 COPY etc/jhove-auto-install.xml /tmp/jhove-auto-install.xml

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -24,6 +24,7 @@ WriteMakefile(
     'Mouse'               => 0,
     'Net::AMQP::RabbitMQ' => 0,
     'Net::Prometheus'     => 0,
+    'Prometheus::Tiny::Shared' => 0,
     'ProgressTracker'     => 0,
     'Readonly'            => 0,
     'Roman'               => 0,

--- a/bin/validate_volume.pl
+++ b/bin/validate_volume.pl
@@ -55,35 +55,33 @@ if ($one_line){
 }
 
 unless ($realmeta) {
+    no warnings 'redefine';
 
-  *HTFeed::Volume::get_sources = sub {
-    return ( 'ht_test','ht_test','ht_test' );
-  };
+    *HTFeed::Volume::get_sources = sub {
+	return ('ht_test', 'ht_test', 'ht_test');
+    };
 
-  # use faked-up marc in case it's missing
-
-  *HTFeed::SourceMETS::_get_marc_from_zephir = sub {
-    my $self = shift;
-    my $marc_path = shift;
-
-    my $identifier = $self->{volume}->get_identifier();
-
-    if (not HTFeed::Stage::Download::download($self,
-      url => "http://zephir.cdlib.org/api/item/" . $self->{volume}->get_identifier(),
-      path => dirname($marc_path),
-      filename => basename($marc_path),
-      not_found_ok => 1)) {
-
-
-      HTFeed::Stage::Download::download($self,
-        url => "http://zephir.cdlib.org/api/item/mdp.39015039746220",
-        path => dirname($marc_path),
-        filename => basename($marc_path),
-        not_found_ok => 1);
-      
-    }
-
-  };
+    # use faked-up marc in case it's missing
+    *HTFeed::SourceMETS::_get_marc_from_zephir = sub {
+	my $self = shift;
+	my $marc_path = shift;
+	my $downloaded = HTFeed::Stage::Download::download(
+	    $self,
+	    url => "http://zephir.cdlib.org/api/item/" . $self->{volume}->get_identifier(),
+	    path => dirname($marc_path),
+	    filename => basename($marc_path),
+	    not_found_ok => 1
+	);
+	if (not $downloaded) {
+	    HTFeed::Stage::Download::download(
+		$self,
+		url => "http://zephir.cdlib.org/api/item/mdp.39015039746220",
+		path => dirname($marc_path),
+		filename => basename($marc_path),
+		not_found_ok => 1
+	    );
+	}
+    };
 }
 
 pod2usage(-msg => 'must specify package type with -p or -d') if not defined $default_packagetype and not defined $dot_packagetype;

--- a/lib/HTFeed/JobMetrics.pm
+++ b/lib/HTFeed/JobMetrics.pm
@@ -1,0 +1,412 @@
+package HTFeed::JobMetrics;
+
+use strict;
+use warnings;
+use Getopt::Long;
+use Log::Log4perl qw(get_logger);
+use Pod::Usage;
+use Prometheus::Tiny::Shared;
+
+=item HTFeed::JobMetrics
+
+=back
+
+... a class that can be used to gather metrics on
+the various stages of an ingest job, such as number of items downloaded,
+number of bytes downloaded and amount of time spent downloading
+(as well as the other job stages, not just download).
+
+This class implements the singleton pattern, and as such has a
+get_instance() method instead of a "normal" new() function.
+
+The singleton instance is stored in the aptly named
+$singleton variable.
+
+=item See e.g.:
+
+  https://www.perl.com/article/52/2013/12/11/Implementing-the-singleton-pattern-in-Perl/
+
+=back
+
+=item Command line options:
+
+=back
+
+=item --help / --usage
+
+Display the POD snippets in this file as a help document.
+
+=cut
+
+# If called from terminal:
+if (!caller) {
+    GetOptions(
+	# these are all booleans
+	'clear'    => \my $clear,
+	'help'     => \my $help,
+	'list'     => \my $list,
+	'location' => \my $location,
+	'pretty'   => \my $pretty,
+	'usage'    => \my $usage,
+	# Each operation takes a metric and/or a value:
+	# add(metric, value),
+	# get_value(metric)
+	# inc(metric),
+	# match(value),
+	# observe(metric, value)
+	'operation=s' => \my $operation,
+	'metric=s'    => \my $metric,
+	'value=s'     => \my $value
+    );
+
+    if ($help or $usage) {
+	pod2usage(2);
+    }
+
+    my $job_metrics = HTFeed::JobMetrics->get_instance();
+    my %valid_operations = (
+	add       => sub { $job_metrics->add($metric, $value) },
+	inc       => sub { $job_metrics->inc($metric) },
+	match     => sub {
+	    my $matches = $job_metrics->match($value);
+	    print join("\n", @$matches) . "\n";
+	},
+	get_value => sub {
+	    my $value = $job_metrics->get_value($metric);
+	    if (defined $value) {
+		print "$value\n";
+	    } else {
+		print "no value found\n";
+	    }
+	},
+	observe => sub { $job_metrics->observe($metric, $value) }
+    );
+
+    # Check the boolean args and act if true.
+    if ($clear) {
+	print "Clearing data...\n";
+	$job_metrics->clear;
+	print "Data cleared.\n";
+    }
+    if ($list) {
+	print "# List of metrics:\n";
+	print join("\n", @{$job_metrics->list_metrics}) . "\n";
+    }
+    if ($location) {
+	print "# HTFeed::JobMetrics data stored in:\n";
+	print $job_metrics->loc . "\n";
+    }
+    if ($pretty) {
+	print $job_metrics->pretty . "\n";
+    }
+
+    # Now check the operation arg
+    if (defined $operation) {
+	if (exists $valid_operations{$operation}) {
+	    print "running operation $operation ...\n";
+	    $valid_operations{$operation}();
+	} else {
+	    print "Invalid operation, exiting.\n";
+	    exit(1);
+	}
+    } else {
+	print "No operation defined, exiting.\n";
+	exit(0);
+    }
+}
+# end commandline stuff
+
+my $singleton = undef;
+
+sub get_instance {
+    # Re-use singleton if defined.
+    if (!defined $singleton) {
+	my $class = shift;
+	my $self  = {};
+	# The default location for storing metrics data is under /tmp/.
+	# You can ovverride that w/ $ENV{'HTFEED_JOBMETRICS_DATA_DIR'}.
+	$self->{file} = "/tmp/htfeed-jobmetrics-data";
+	if (defined $ENV{'HTFEED_JOBMETRICS_DATA_DIR'}) {
+	    $self->{file} = $ENV{'HTFEED_JOBMETRICS_DATA_DIR'};
+	}
+	$self->{prom} = Prometheus::Tiny::Shared->new(
+	    filename => $self->{file}
+	);
+	$singleton = bless($self, $class);
+	$singleton->_setup_metrics();
+    }
+    return $singleton;
+}
+
+=item --loc
+
+Show where the data is stored.
+
+=cut
+
+sub loc {
+    my $self = shift;
+    $self->{file};
+}
+
+=item --list
+
+Show names of all known metrics.
+
+=cut
+
+sub list_metrics {
+    my $self = shift;
+    [sort keys %{$self->{metrics}}];
+}
+
+=item --pretty
+
+Full, somewhat readable, accounting of known metrics and their values.
+
+Call this to export/harvest/scrape data from the running production pod.
+
+=cut
+
+sub pretty {
+    my $self = shift;
+    $self->{prom}->format;
+}
+
+=item --clear
+
+Irrevocably delete job metrics (see --loc for where that is)
+
+=cut
+
+sub clear {
+    my $self = shift;
+    $self->{prom}->clear;
+}
+
+=item --operation
+
+--operation takes an operation name (match / inc / add/ observe),
+a --metric and/or a --value. See below for the different operations.
+
+=item --operation match --value x
+
+Return metrics matching x.
+
+=cut
+
+sub match {
+    my $self   = shift;
+    my $value  = shift;
+    die "match requires a value" if !defined $value;
+
+    my @pretties = split("\n", $self->pretty);
+    [grep { /$value/ } @pretties];
+}
+
+=item --operation get_value --metric x
+
+Returns the value for metric x, 0 in case of any issues.
+
+=cut
+
+sub get_value {
+    my $self   = shift;
+    my $metric = shift;
+
+    if (!$self->_valid_metric($metric)) {
+	return 0;
+    }
+
+    my $match = $self->match("^$metric");
+    if (scalar @$match == 1) {
+	if ($$match[0] =~ /(\d+(?:\.\d+)?)$/) {
+	    my $matched_numerical_value = $1;
+	    return $matched_numerical_value;
+	}
+    }
+    get_logger()->warn("JobMetric found no value for $metric");
+    return 0;
+}
+
+=item --operation inc --metric x
+
+Increment metric x by 1.
+
+=cut
+
+sub inc {
+    my $self   = shift;
+    my $metric = shift;
+    if ($self->_valid_metric($metric)) {
+	$self->{prom}->inc($metric);
+    }
+}
+
+=item --operation add --metric x --value y
+
+Adds arbitrary numeric value y to the metric x.
+
+=cut
+
+sub add {
+    my $self   = shift;
+    my $metric = shift;
+    my $value  = shift;
+
+    # Make sure $value is defined and numeric
+    unless (defined $value) {
+	get_logger()->warn("Undefined value given for $metric");
+	return;
+    }
+    unless ($value + 0) {
+	get_logger()->warn("Non-numeric value \"$value\" given for $metric");
+	return;
+    }
+
+    $self->_valid_metric($metric) && $self->{prom}->add($metric, $value);
+}
+
+=item --operation observe --metric x --value y
+
+Add value y to the histogram metric x.
+
+Note that histograms must be set up with buckets ahead of time.
+
+=cut
+
+sub observe {
+    my $self   = shift;
+    my $metric = shift;
+    my $value  = shift;
+
+    # Make sure $value is numeric
+    unless ($value + 0) {
+	get_logger()->warn("Non-numeric value \"$value\" given for $metric");
+	return;
+    }
+
+    $self->_valid_metric($metric) && $self->{prom}->histogram_observe($metric, $value);
+}
+
+# "private" from here on, indicated with _leading_underscores
+# in method names
+
+# Check that only valid metrics are used,
+# or make an intelligent complaint.
+# e.g. $job_metrics->_valid_metric("Unpack_seconds") # -> 1
+# e.g. $job_metrics->_valid_metric("invalid metric name") # -> warn & 0
+sub _valid_metric {
+    my $self   = shift;
+    my $metric = shift;
+
+    return 1 if defined $self->{metrics}->{$metric};
+
+    # caller 1: we don't want the line number from the call inside this package.
+    # remember, this is a "private" method.
+    my (undef, $filename, $line) = caller(1);
+    get_logger()->warn("invalid metric name \"$metric\" at $filename:$line");
+    # switch from warn to die to ensure no invalid metric names slip thru:
+    # die ("invalid metric name \"$metric\" at $filename:$line");
+    return 0;
+}
+
+sub _setup_metrics {
+    my $self = shift;
+    my $prom = $self->{prom};
+
+    # Prefix all metric names with:
+    my $pfx = "ingest";
+
+    # Each element x in this array gets turned into 3 prom declarations:
+    # x_seconds, x_bytes and x_items
+    # Names are based on the downcased class name of the stage.
+    my @measurable_stages = (
+	'collate',
+	'download',
+	'download_dropbox',
+	'download_google',
+	'download_ia',
+	'handle',
+	'imageremediate',
+	'mets',
+	'pack',
+	'sourcemets',
+	'unpack',
+	'verifymanifest',
+	'volumevalidator'
+    );
+
+    my @scales = qw(items bytes seconds);
+    # essentially, generate: @measurable_stages x @scales
+    # so that we get Pack_items, Pack_bytes, Pack_seconds ... etc
+
+    # In case we want different bucket setup for different scales.
+    # Leaving bytes and seconds commented out for now, meaning
+    # we will not have any histograms.
+    my %scale_buckets = (
+	# bytes   => _byte_buckets(),
+	# seconds => _second_buckets()
+    );
+
+    $self->{metrics} = {};
+    foreach my $stage (@measurable_stages) {
+	foreach my $scale (@scales) {
+	    my $metric_name = join("_", ($pfx, $stage, $scale));
+	    $self->{metrics}->{$metric_name} = 1;
+	    if (defined $scale_buckets{$scale}) {
+		# If $scale defined in %scale_buckets, make $metric_name a histogram
+		# and use the bucket scheme appropriate for the scale
+		# here, scale is either bytes or seconds
+		my $buckets = $scale_buckets{$scale};
+		$prom->declare(
+		    $metric_name,
+		    type    => "histogram",
+		    buckets => $buckets
+		);
+	    } else {
+		# If nothing in particular was said abut the metric or the scale,
+		# turn it into a counter.
+		$prom->declare($metric_name, type => "counter");
+	    }
+	}
+    }
+
+    # Put in any one-offs that don't fit the above algorithm here:
+    $self->{metrics}->{$pfx . "_imageremediate_images"} = 1;
+    $prom->declare($pfx . "_imageremediate_images", type => "counter");
+}
+
+# NB that if you change these bucket definitions, you need to clear
+# existing data, or prometheus will complain:
+# "redeclaration of <metric_name> with mismatched meta"
+# Manipulate _setup_metrics to change which metrics are histograms,
+# and which buckets they should use.
+sub _second_buckets {
+    [
+	0.001, # 1 millisec
+	0.01,
+	0.1,
+	1,     # 1 sec
+	10,
+	60,    # 1 minute
+	300,   # 5 minutes
+	6000,  # 10 minutes
+	3_600, # 1 hour
+	7_200, # 2 hours
+    ];
+}
+
+sub _byte_buckets {
+    [
+	1_000,
+	10_000,
+	100_000,
+	1_000_000,
+	10_000_000,
+	100_000_000,
+	1_000_000_000
+    ];
+}
+
+1;

--- a/lib/HTFeed/PackageType/Simple/Download.pm
+++ b/lib/HTFeed/PackageType/Simple/Download.pm
@@ -3,56 +3,73 @@ package HTFeed::PackageType::Simple::Download;
 use warnings;
 use strict;
 use base qw(HTFeed::Stage::Download);
+use File::Find;
 use HTFeed::Config qw(get_config);
-use Log::Log4perl qw(get_logger);
 use HTFeed::Rclone;
+use Log::Log4perl qw(get_logger);
 
 sub run {
-  my $self = shift;
+    my $self = shift;
 
-  my $volume = $self->{volume};
-  # check if the item already exists at $volume->get_sip_location()
-  my $sip_loc = $volume->get_sip_location();
-  if (-f $sip_loc) {
-    get_logger->trace("$sip_loc already exists");
-  } else {
-    $self->download($volume);
-  }
-  $self->_set_done();
-  return $self->succeeded();
+    my $volume = $self->{volume};
+    # check if the item already exists at $volume->get_sip_location()
+    my $sip_loc = $volume->get_sip_location();
+    if (-f $sip_loc) {
+	get_logger->trace("$sip_loc already exists");
+    } else {
+	$self->download($volume);
+    }
+    $self->_set_done();
+    return $self->succeeded();
 }
 
 sub download {
-  my $self   = shift;
-  my $volume = shift;
+    my $self   = shift;
+    my $volume = shift;
 
-  my $url;
+    my $url;
 
-  if(!get_config('use_dropbox')) {
-    $self->set_error('MissingFile', file => $volume->get_sip_location(), detail => "Dropbox download disabled and file not found");
-    return;
-  }
+    if (!get_config('use_dropbox')) {
+	$self->set_error(
+	    'MissingFile',
+	    file   => $volume->get_sip_location(),
+	    detail => "Dropbox download disabled and file not found"
+	);
+	return;
+    }
 
-  eval {
-    $url = $volume->dropbox_url;
-  };
-  if ($@) {
-    $self->set_error('MissingFile', file => $volume->get_sip_location(), detail => $@);
-    return;
-  }
-  my $sip_directory = sprintf "%s/%s", $volume->get_sip_directory(), $volume->get_namespace();
-  if (not -d $sip_directory) {
-    get_logger->trace("Creating download directory $sip_directory");
-    mkdir($sip_directory, 0770) or $self->set_error('OperationFailed', operation=>'mkdir',
-                                                    detail=>"$sip_directory could not be created");
-  }
-  eval {
-    my $rclone = HTFeed::Rclone->new;
-    $rclone->copy($url, $sip_directory);
-  };
-  if ($@) {
-    $self->set_error('OperationFailed', detail => $@);
-  }
+    eval {
+	$url = $volume->dropbox_url;
+    };
+    if ($@) {
+	$self->set_error(
+	    'MissingFile',
+	    file   => $volume->get_sip_location(),
+	    detail => $@
+	);
+	return;
+    }
+    my $sip_directory = sprintf "%s/%s", $volume->get_sip_directory(), $volume->get_namespace();
+    if (not -d $sip_directory) {
+	get_logger->trace("Creating download directory $sip_directory");
+	mkdir($sip_directory, 0770) or
+	$self->set_error(
+	    'OperationFailed',
+	    operation => 'mkdir',
+	    detail    => "$sip_directory could not be created"
+	);
+    }
+
+    eval {
+	my $rclone = HTFeed::Rclone->new;
+	$rclone->copy($url, $sip_directory);
+	my $download_size;
+	find (sub { -f and ( $download_size += -s ) }, $sip_directory);
+	$self->{job_metrics}->add("ingest_download_bytes", $download_size);
+    };
+    if ($@) {
+	$self->set_error('OperationFailed', detail => $@);
+    }
 }
 
 1;

--- a/lib/HTFeed/PackageType/Simple/Unpack.pm
+++ b/lib/HTFeed/PackageType/Simple/Unpack.pm
@@ -3,34 +3,32 @@ package HTFeed::PackageType::Simple::Unpack;
 use strict;
 use warnings;
 use base qw(HTFeed::Stage::Unpack);
-use Log::Log4perl qw(get_logger);
-use HTFeed::Config qw(get_config);
 use File::Find;
+use HTFeed::Config qw(get_config);
+use Log::Log4perl qw(get_logger);
 
 sub run {
-  my $self = shift;
-  $self->SUPER::run();
+    my $self = shift;
+    $self->SUPER::run();
 
+    my $volume       = $self->{volume};
+    my $packagetype  = $volume->get_packagetype();
+    my $pt_objid     = $volume->get_pt_objid();
+    my $download_dir = get_config('staging'=>'download');
+    my $dest         = $volume->get_preingest_directory();
+    my $file         = $volume->get_sip_location();
 
-  my $volume = $self->{volume};
-  my $packagetype = $volume->get_packagetype();
-  my $pt_objid = $volume->get_pt_objid();
+    if (-e $file) {
+	$self->unzip_file($file,$dest);
+	$self->_set_done();
+    } else {
+	$self->set_error(
+	    "MissingFile",
+	    file => $volume->get_sip_location
+	);
+    }
 
-  my $download_dir = get_config('staging'=>'download');
-
-  my $dest = $volume->get_preingest_directory();
-
-  my $file = $volume->get_sip_location();
-
-  if(-e $file) {
-    $self->unzip_file($file,$dest);
-    $self->_set_done();
-  } else {
-    $self->set_error("MissingFile",file=>$volume->get_sip_location);
-  }
-
-  return $self->succeeded();
+    return $self->succeeded();
 }
 
 1;
-

--- a/lib/HTFeed/Stage.pm
+++ b/lib/HTFeed/Stage.pm
@@ -6,14 +6,14 @@ package HTFeed::Stage;
 
 use warnings;
 use strict;
-use Carp;
-use Log::Log4perl qw(get_logger);
-use File::Find;
-use HTFeed::Config qw(get_config);
-use POSIX qw(ceil);
-
 use base qw(HTFeed::SuccessOrFailure);
 
+use Carp;
+use File::Find;
+use HTFeed::Config qw(get_config);
+use HTFeed::JobMetrics;
+use Log::Log4perl qw(get_logger);
+use POSIX qw(ceil);
 
 sub new {
     my $class = shift;
@@ -23,11 +23,14 @@ sub new {
         croak __PACKAGE__ . ' can only construct subclass objects';
     }
 
+    # No class inheriting from HTFeed::Stage needs to instantiate
+    # its own $self->{job_metrics} for storing JobMetrics.
     my $self = {
         volume => undef,
         @_,
         has_run => 0,
         failed  => 0,
+	job_metrics => HTFeed::JobMetrics->get_instance
     };
 
     unless ( $self->{volume} && $self->{volume}->isa("HTFeed::Volume") ) {

--- a/lib/HTFeed/Stage/DirectoryMaker.pm
+++ b/lib/HTFeed/Stage/DirectoryMaker.pm
@@ -1,11 +1,11 @@
 package HTFeed::Stage::DirectoryMaker;
 
-use warnings;
 use strict;
-use Carp;
-use Filesys::Df;
+use warnings;
 
 use base qw(HTFeed::Stage);
+use Carp;
+use Filesys::Df;
 use HTFeed::Config;
 
 =head1 NAME

--- a/lib/HTFeed/Stage/Download.pm
+++ b/lib/HTFeed/Stage/Download.pm
@@ -2,12 +2,11 @@ package HTFeed::Stage::Download;
 
 use warnings;
 use strict;
-use LWP::UserAgent;
-use HTFeed::Version;
-use Date::Manip;
-
 use base qw(HTFeed::Stage);
 
+use Date::Manip;
+use HTFeed::Version;
+use LWP::UserAgent;
 use Log::Log4perl qw(get_logger);
 
 =head1 NAME
@@ -64,8 +63,9 @@ sub download{
 
     if( $response->is_success() ){
         my $size = (-s $pathname);
+	$self->{job_metrics}->add("ingest_download_bytes", $size);
         my $date = $response->header('last-modified');
-        utime(time,UnixDate(ParseDate($date),"%s"),$pathname);
+        utime(time, UnixDate(ParseDate($date), "%s"), $pathname);
         my $expected_size = $response->header('content-length');
         if (not defined $expected_size or $size eq $expected_size){
             get_logger()->trace("Downloading $url succeeded, $size bytes downloaded");

--- a/lib/HTFeed/Stage/ReMETS.pm
+++ b/lib/HTFeed/Stage/ReMETS.pm
@@ -1,22 +1,22 @@
 #!/usr/bin/perl
 
 package HTFeed::Stage::ReMETS;
+
 use strict;
 use warnings;
-use Log::Log4perl qw(get_logger);
-use List::MoreUtils qw(pairwise);
-use HTFeed::XMLNamespaces qw(:namespaces);
 use base qw(HTFeed::Stage);
 
-# Rebuilds the METS for the package from what's in the repository.
+use HTFeed::XMLNamespaces qw(:namespaces);
+use List::MoreUtils qw(pairwise);
+use Log::Log4perl qw(get_logger);
 
+# Rebuilds the METS for the package from what's in the repository.
 
 sub new {
     my $class = shift;
 
     my $self = $class->SUPER::new(
         @_,
-
         #		files			=> [],
         #		dir			=> undef,
         #		mets_name		=> undef,
@@ -30,11 +30,8 @@ sub new {
 sub run {
     my $self = shift;
     my $volume = $self->{volume};
-
     # reset md5 checksum source to repo METS file??
-
     # add uplift METS events; mess with PREMIS events we will include.
-
     my $nspkg = $volume->get_nspkg();
     my $pkg_class = ref($nspkg);
     no strict 'refs';
@@ -57,15 +54,16 @@ sub run {
     $mets_stage->run();
 
     # compare new METS to old mets. must have:
-
     my $new_mets_file = $mets_stage->{outfile};
     $self->{new_mets_file} = $new_mets_file;
     my $new_xpc = $volume->_parse_xpc($new_mets_file);
 
     # make sure file count, page count, objid are the same
-    my @queries = ("//premis:significantProperties[premis:significantPropertiesType='file count']/premis:significantPropertiesValue",
+    my @queries = (
+	"//premis:significantProperties[premis:significantPropertiesType='file count']/premis:significantPropertiesValue",
         "//premis:significantProperties[premis:significantPropertiesType='page count']/premis:significantPropertiesValue",
-        '//mets:mets/@OBJID');
+        '//mets:mets/@OBJID'
+    );
     foreach my $query (@queries) {
         my $old_val = $old_xpc->findvalue($query);
         # some old METS don't have the file count /page count
@@ -76,7 +74,7 @@ sub run {
     }
 
     # for each premis2 event type in old METS //premis:eventType/text()
-      # count of events in new PREMIS much match count in old PREMIS //premis:eventType='$event_type'
+    # count of events in new PREMIS much match count in old PREMIS //premis:eventType='$event_type'
     # is this an event we're migrating?
     my $migrate_events = $nspkg->get('migrate_events');
     foreach my $event_type_node ($old_xpc->findnodes("//premis:eventType")) {
@@ -96,21 +94,34 @@ sub run {
 
     # for each premis2 event type in new METS, verify a few things..
     foreach my $event_node ($new_xpc->findnodes("//premis:event")) {
-        $self->assert_equal("UUID",$new_xpc->findvalue(".//premis:eventIdentifierType",$event_node),"eventIdentifierType");
+        $self->assert_equal(
+	    "UUID",
+	    $new_xpc->findvalue(".//premis:eventIdentifierType", $event_node),
+	    "eventIdentifierType"
+	);
 
         my $identifier = $new_xpc->findvalue(".//premis:eventIdentifierValue",$event_node);
         if(not defined $identifier or $identifier !~ /^[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}$/) {
-            $self->set_error("BadValue",field=>"eventIdentifierValue",file=>$new_mets_file,value=>$identifier);
+            $self->set_error(
+		"BadValue",
+		field => "eventIdentifierValue",
+		file  => $new_mets_file,
+		value => $identifier
+	    );
         }
     }
 
     # verify only permitted linkingAgentIdentifierTypes - tool and HathiTrust Agent ID
     foreach my $linkingAgentIdentfierType ($new_xpc->findnodes("//premis:linkingAgentIdentifierType")) {
       my $value = $linkingAgentIdentfierType->textContent();
-      if($value ne 'HathiTrust Institution ID' and $value ne 'tool') {
-        $self->set_error("BadValue",field=>"linkingAgentIdentifierType",actual=>$value,file=>$self->{new_mets_file});
+      if ($value ne 'HathiTrust Institution ID' and $value ne 'tool') {
+	  $self->set_error(
+	      "BadValue",
+	      field  => "linkingAgentIdentifierType",
+	      actual => $value,
+	      file   => $self->{new_mets_file}
+	  );
       }
-
     }
 
     # for each //mets:file
@@ -120,8 +131,12 @@ sub run {
         my $file_name = $old_xpc->findvalue('./mets:FLocat/@xlink:href',$old_file);
         my $new_file = ($new_xpc->findnodes("//mets:file[mets:FLocat/\@xlink:href='$file_name']"))[0];
 
-        if(not defined $new_file) {
-            $self->set_error("BadFile",file=>$file_name,detail=>"Missing reference to file in uplifted METS");
+        if (not defined $new_file) {
+            $self->set_error(
+		"BadFile",
+		file   => $file_name,
+		detail => "Missing reference to file in uplifted METS"
+	    );
         }
 
         foreach my $attribute ($old_file->attributes(), $new_file->attributes()) {
@@ -150,20 +165,26 @@ sub run {
 
         my @old_fptrs;
         my @new_fptrs;
-        foreach my $fileid ($old_xpc->findnodes("./mets:fptr/\@FILEID",$old_div)) {
+        foreach my $fileid ($old_xpc->findnodes("./mets:fptr/\@FILEID", $old_div)) {
             $fileid = $fileid->getValue();
             push(@old_fptrs,$old_xpc->findnodes("//mets:file[\@ID='$fileid']/mets:FLocat/\@xlink:href"));
         }
-        foreach my $fileid ($new_xpc->findnodes("./mets:fptr/\@FILEID",$new_div)) {
+        foreach my $fileid ($new_xpc->findnodes("./mets:fptr/\@FILEID", $new_div)) {
             $fileid = $fileid->getValue();
             push(@new_fptrs,$new_xpc->findnodes("//mets:file[\@ID='$fileid']/mets:FLocat/\@xlink:href"));
         }
-        $self->assert_equal(scalar(@old_fptrs),scalar(@new_fptrs),
-            "file count for mets:div\@ORDER=$order");
+        $self->assert_equal(
+	    scalar(@old_fptrs),
+	    scalar(@new_fptrs),
+            "file count for mets:div\@ORDER=$order"
+	);
 
         foreach my $attribute ($old_div->attributes()) {
-            $self->assert_equal($attribute->getValue(),
-                $new_div->getAttribute($attribute->nodeName()), $attribute->nodeName());
+            $self->assert_equal(
+		$attribute->getValue(),
+		$new_div->getAttribute($attribute->nodeName()),
+		$attribute->nodeName()
+	    );
         }
 
         foreach my $attribute ($new_div->attributes()) {
@@ -173,7 +194,7 @@ sub run {
 
         @old_fptrs = sort(map { $_->getValue() } @old_fptrs);
         @new_fptrs = sort(map { $_->getValue() } @new_fptrs);
-         pairwise { $self->assert_equal($a,$b,"div\@ORDER='$order' file") }
+         pairwise { $self->assert_equal($a, $b, "div\@ORDER='$order' file") }
             (@old_fptrs, @new_fptrs);
 
     }
@@ -186,22 +207,36 @@ sub run {
         $mets_old = $mets_dest;
         $mets_old =~ s/\.mets\.xml$/.pre_uplift.mets.xml/;
     } else {
-        $self->set_error("BadFile",file=>$mets_dest,detail=>"Unexpected file name for METS in repository",expected=>"*.mets.xml");
+        $self->set_error(
+	    "BadFile",
+	    file     => $mets_dest,
+	    detail   => "Unexpected file name for METS in repository",
+	    expected => "*.mets.xml"
+	);
     }
 
     # move new METS into place
     if (-f $mets_source and -f $mets_dest and defined $mets_old){
         # move mets and zip to repo
-        system('cp','-f',$mets_dest,$mets_old)
-            and $self->set_error('OperationFailed', operation => 'cp', detail => "cp $mets_dest $mets_old failed with status: $?");
-            
-        system('cp','-f',$mets_source,$mets_dest)
-            and $self->set_error('OperationFailed', operation => 'cp', detail => "cp $mets_source $mets_dest failed with status: $?");
+        system('cp', '-f', $mets_dest, $mets_old)
+	and $self->set_error(
+	    'OperationFailed',
+	    operation => 'cp',
+	    detail    => "cp $mets_dest $mets_old failed with status: $?"
+	);
+
+        system('cp', '-f', $mets_source, $mets_dest)
+	and $self->set_error(
+	    'OperationFailed',
+	    operation => 'cp',
+	    detail    => "cp $mets_source $mets_dest failed with status: $?"
+	);
 
         $self->_set_done();
-        return $self->succeeded();
+	$self->{job_metrics}->add("ingest_remets_bytes", -s $mets_dest);
+
+	return $self->succeeded();
     }
-    
 }
 
 sub clean_always {
@@ -222,11 +257,17 @@ sub stage_info {
 }
 
 sub assert_equal {
-    my $self= shift;
-    my ($old_val,$new_val,$field) = @_;
+    my $self = shift;
+    my ($old_val, $new_val, $field) = @_;
     get_logger->trace("field: $field, $new_val = $old_val ?");
     if(not defined $old_val or not defined $new_val or $old_val ne $new_val) {
-        $self->set_error("BadValue",field=>$field,actual=>$new_val,expected=>$old_val,file=>$self->{new_mets_file});
+        $self->set_error(
+	    "BadValue",
+	    field    => $field,
+	    actual   => $new_val,
+	    expected => $old_val,
+	    file     => $self->{new_mets_file}
+	);
         return 0;
     }
     return 1;
@@ -235,7 +276,6 @@ sub assert_equal {
 # page data gatherer that uses page info from existing repository METS and does
 
 sub get_page_data_repository_mets {
-
     my $self = shift;
     my $file = shift;
     my $xc   = $self->{old_xpc};
@@ -244,12 +284,10 @@ sub get_page_data_repository_mets {
         my $page_data = {};
         # Extract info from the physical structmap
         foreach my $page ($xc->findnodes('//METS:structMap/METS:div/METS:div')) {
-
             my $pagenum = $page->getAttribute('ORDERLABEL');
             my $tags = $page->getAttribute('LABEL');
 
-            foreach my $fptr ( $page->getChildrenByTagNameNS( NS_METS, 'fptr' ) )
-            {
+            foreach my $fptr ($page->getChildrenByTagNameNS(NS_METS, 'fptr')) {
                 my $fileid = $fptr->getAttribute('FILEID');
                 my $filename = $xc->findvalue(qq(//METS:file[\@ID='$fileid']/METS:FLocat/\@xlink:href));
                 $page_data->{$filename} = {
@@ -262,7 +300,6 @@ sub get_page_data_repository_mets {
     }
 
     return $self->{page_data}{$file};
-
 }
 
 1;

--- a/lib/HTFeed/Stage/Unpack.pm
+++ b/lib/HTFeed/Stage/Unpack.pm
@@ -2,38 +2,50 @@ package HTFeed::Stage::Unpack;
 
 use warnings;
 use strict;
-
 use base qw(HTFeed::Stage::DirectoryMaker Exporter);
-
 use Log::Log4perl qw(get_logger);
-
 our @EXPORT_OK = qw(unzip_file);
 
 sub stage_info{
-    return {success_state => 'unpacked', failure_state => 'ready'};
+    return {
+	success_state => 'unpacked',
+	failure_state => 'ready'
+    };
 }
 
 # unzip_file $self,$infile,$outdir,$otheroptions
 sub unzip_file {
     # extract - not using Archive::Zip because it doesn't handle ZIP64
-    return _extract_file(q(yes 'n' 2>/dev/null | unzip -LL -j -o -q '%s' -d '%s' %s 2>&1),@_);
+    return _extract_file(
+	q(yes 'n' 2>/dev/null | unzip -LL -j -o -q '%s' -d '%s' %s 2>&1),
+	@_
+    );
 }
 
 # unzip_file $self,$infile,$outdir,$otheroptions
 sub unzip_file_preserve_case {
     # extract - not using Archive::Zip because it doesn't handle ZIP64
-    return _extract_file(q(yes 'n' 2>/dev/null | unzip -j -o -q '%s' -d '%s' %s 2>&1),@_);
+    return _extract_file(
+	q(yes 'n' 2>/dev/null | unzip -j -o -q '%s' -d '%s' %s 2>&1),
+	@_
+    );
 }
 
 # untgz_file $self,$infile,$outdir,$otheroptions
 sub untgz_file {
     # extract - not using Archive::Tar because it is very slow
-    return _extract_file(q(tar -zx -f '%s' -C '%s' %s 2>&1),@_);
+    return _extract_file(
+	q(tar -zx -f '%s' -C '%s' %s 2>&1),
+	@_
+    );
 }
 
 sub untar_file {
     # extract - not using Archive::Tar because it is very slow
-    return _extract_file(q(tar -x -f '%s' -C '%s' %s 2>&1),@_);
+    return _extract_file(
+	q(tar -x -f '%s' -C '%s' %s 2>&1),
+	@_
+    );
 }
 
 sub _extract_file {
@@ -48,12 +60,16 @@ sub _extract_file {
     get_logger()->trace("Extracting $infile with command $full_command");
 
     # make directory
-    if(not -d $outdir) {
-      mkdir($outdir, 0770 ) or $requester->set_error('OperationFailed',operation=>'mkdir',detail=>"$outdir could not be created");
+    if (not -d $outdir) {
+	mkdir($outdir, 0770 ) or $requester->set_error(
+	    'OperationFailed',
+	    operation => 'mkdir',
+	    detail    => "$outdir could not be created"
+	);
     }
 
     if (not -e $infile ) {
-        $requester->set_error('MissingFile',file=>$infile);
+        $requester->set_error('MissingFile', file => $infile);
     }
 
     my $rstring = `$full_command`;
@@ -61,8 +77,13 @@ sub _extract_file {
 
     # 1 is a non-fatal warning for both tar and unzip -- ignore it and let
     # manifest / validation stuff figure it out
-    if($rval != 0 and $rval != (1 << 8)) {
-        $requester->set_error('OperationFailed',operation=>'unzip',exitstatus=>$rval,detail=>$rstring);
+    if ($rval != 0 and $rval != (1 << 8)) {
+        $requester->set_error(
+	    'OperationFailed',
+	    operation  => 'unzip',
+	    exitstatus => $rval,
+	    detail     => $rstring
+	);
         return;
     }
 

--- a/t/job_metrics.t
+++ b/t/job_metrics.t
@@ -1,0 +1,104 @@
+use strict;
+use warnings;
+
+use Data::Dumper;
+use FindBin;
+use lib "$FindBin::Bin/lib";
+use Test::Spec;
+use Test::Exception;
+
+use HTFeed::JobMetrics;
+
+describe "HTFeed::JobMetrics" => sub {
+    # SETUP start
+    my $jm = HTFeed::JobMetrics->get_instance;
+    my $item_metric = "ingest_pack_items";
+    my $byte_metric = "ingest_pack_bytes";
+    my $invalid_metric = "not a valid metric";
+    before each => sub {
+	$jm->clear() if defined $jm;
+    };
+    # SETUP end
+
+    # TESTS start
+    it "says where the data is stored" => sub {
+	# Either the env var is defined, and that's what we use,
+	# or we default to a /tmp/ location.
+	if (defined $ENV{'HTFEED_JOBMETRICS_DATA_DIR'}) {
+	    ok($jm->loc eq $ENV{'HTFEED_JOBMETRICS_DATA_DIR'});
+	} else {
+	    ok($jm->loc eq "/tmp/htfeed-jobmetrics-data");
+	}
+    };
+
+    it "lists all known metrics, alphabetically" => sub {
+	my $metrics = $jm->list_metrics;
+	ok(@$metrics[0]  eq "ingest_collate_bytes");
+	ok(@$metrics[-1] eq "ingest_volumevalidator_seconds");
+    };
+    it "reports no value for an empty matching metric" => sub {
+	# get_value is a more useful method, most of the time
+	# but match is at least useful for debug/dev purposes
+	my $matching = $jm->match($item_metric);
+	ok(@$matching == 1);
+	ok($$matching[0] =~ /^# TYPE $item_metric counter$/);
+    };
+    it "reports 0 for any empty or non-existing metrics" => sub {
+	my $value_invalid_metric = $jm->get_value($invalid_metric);
+	my $value_valid_metric   = $jm->get_value($item_metric);
+	ok($value_invalid_metric == 0);
+	ok($value_valid_metric   == 0);
+    };
+    it "reports a value for a non-empty matching metric" => sub {
+	$jm->inc($item_metric);
+	$jm->inc($item_metric);
+	ok($jm->get_value($item_metric) == 2);
+    };
+    it "allows arbitrary addition" => sub {
+	$jm->add($byte_metric, 1.01);
+	$jm->add($byte_metric, 3.03);
+	ok($jm->get_value($byte_metric) == 4.04);
+    };
+    it "warns and returns [] if given an invalid metric name" => sub {
+	ok($jm->inc($invalid_metric) == 0);
+	my $match = $jm->match($invalid_metric);
+	ok(ref($match) eq "ARRAY");
+	ok(@$match == 0);
+    };
+    it "allows multiple distinct jms writing (in sequence) to the same metrics file" => sub {
+	# Make 5 separate jm objects that all inc $item_metric once,
+	# and expect to see "$item_metric 5" in the output for
+	# match($item_metric).
+	my $expected_count = 5;
+	# Get 5 jm instances
+	my @jms = (map { HTFeed::JobMetrics->get_instance } (1..5));
+	foreach my $sequence_jm (@jms) {
+	    $sequence_jm->inc($item_metric);
+	}
+	ok($jm->get_value($item_metric) == 5);
+    };
+    it "allows multiple distinct jms writing (in parallel) to the same metrics file" => sub {
+	my $fork_count = 5;
+	foreach my $_i (1 .. $fork_count) {
+	    my $pid = fork; # do the fork
+	    die "failed to fork: $!" unless defined $pid;
+	    next if $pid;
+	    # do the work:
+	    $jm->inc($item_metric);
+	    # CAVEAT: this exit will trigger after-each hook in SETUP if any,
+	    # which can make for some really frustrating debugging.
+	    exit;
+	}
+	my $kid;
+	do {
+	    $kid = waitpid -1, 0;
+	} while ($kid > 0);
+	ok($jm->get_value($item_metric) == 5);
+    };
+
+    # TESTS todo
+    it "could have some histogram tests once we figure out histograms" => sub {};
+    # TESTS end
+};
+
+runtests unless caller;


### PR DESCRIPTION
Originating ticket: https://hathitrust.atlassian.net/browse/DEV-1075

## What?

This PR adds the class `HTFeed::JobMetrics` that can be used to gather metrics on the various stages of a job, such as number of items downloaded, number of bytes downloaded and amount of time spent downloading (as well as the other job stages, not just download).

`HTFeed::JobMetrics` specifies which kinds of metrics can be used, knows how to update them, pretty print and clear metrics. It has its own minimal CLI (see `perl lib/HTFeed/JobMetrics.pm --usage`)

## Why?

We want a better understanding of how much time is spent on different parts of the Ingest workflow.

## How?

`--help` or `--usage` should provide a short usage page.

Each measured job reports how long it took to `HTFeed::JobMetrics`, which passes it on to `Prometheus::Tiny::Shared` which saves the data point in a `Hash::SharedMem`.

The `Hash::SharedMem` needs to live somewhere on the filesystem. For now, it defaults to a subdir of `/tmp/`:
```perl
$self->{file} = "/tmp/HTFeed::JobMetrics::Data";
if (defined $ENV{'HTFEED_JOBMETRICS_DATA_DIR'}) {
    $self->{file} = $ENV{'HTFEED_JOBMETRICS_DATA_DIR'};
}
$self->{prom} = Prometheus::Tiny::Shared->new(filename => $self->{file});
```
... but that can be changed by setting `$ENV{'HTFEED_JOBMETRICS_DATA_DIR'}` to some other path.

Metrics will generally change when jobs are run. 
For ease of testing, they can be viewed/manipulated directly via commandline:

```
$ docker compose run --rm test bash

perl lib/HTFeed/JobMetrics.pm --clear
  Clearing data...
  Data cleared.
  No operation defined, exiting.

perl lib/HTFeed/JobMetrics.pm --operation match --value collate
  running operation match ...
  # TYPE ingest_collate_bytes counter
  # TYPE ingest_collate_items counter
  # TYPE ingest_collate_seconds counter

perl lib/HTFeed/JobMetrics.pm --operation inc --metric ingest_collate_items
  running operation inc ...

perl lib/HTFeed/JobMetrics.pm --operation add --metric ingest_collate_bytes --value 2460
  running operation add ...

perl lib/HTFeed/JobMetrics.pm --operation match --value collate
  running operation match ...
  # TYPE ingest_collate_bytes counter
  ingest_collate_bytes 2460
  # TYPE ingest_collate_items counter
  ingest_collate_items 1
  # TYPE ingest_collate_seconds counter
```

Get all metrics with:
```
$ docker compose run --rm test perl lib/HTFeed/JobMetrics.pm --pretty
```

## Limitations

Note that if you call from outside docker, and have not set `$ENV{'HTFEED_JOBMETRICS_DATA_DIR'}`, then the metrics data will default to being stored in the container's `/tmp`, and that data will not persist between commands.

Far from every operation that could be measured is being measured, but the size of this PR is getting out of hand and those missing pieces could be added incrementally after we've proven whether this concept works in production.

## Tests

`docker compose run --rm test perl t/job_metrics.t` to run just the new tests.
`docker compose run --rm test` to run all tests.

## Where?

These are some of the main changes per file:

* `lib/HTFeed/JobMetrics.pm` new class, the main innovation in this PR.
* `t/job_metrics.t` tests for the new class.
* `lib/HTFeed/QueueRunner.pm` uses JobMetrics to observe `_items` and `_seconds` metrics for each job stage in `run_job_sequence` (this is a big and important part of this PR so this needs to work)
* `Makefile.pl` getting required perl module `Prometheus::Tiny::Shared`.
* `lib/HTFeed/Stage.pm` giving a `JobMetrics` object (`$self->{job_metrics}`) to all `Stage` objects and their heirs.

The rest of the `Files changed` are about using `HTFeed::JobMetrics`, plus some cleanup/cosmetics.