### PR TITLE
Prometheus exporter for metrics

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libmailtools-perl \
     libmouse-perl \
     libnet-prometheus-perl \
+    libplack-perl \
     libreadonly-perl \
     libreadonly-xs-perl \
     libroman-perl \

--- a/bin/metrics_exporter.pl
+++ b/bin/metrics_exporter.pl
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 use HTFeed::JobMetrics;
 use Plack::Response;
 
@@ -10,7 +13,6 @@ my $app = sub {
   my $env = shift;
 
   my $rendered = $metrics->pretty();
-  my $headers = { "Content-Type" => "text/plain" };
 
   my $response = Plack::Response->new();
   $response->content_type('text/plain');
@@ -18,13 +20,11 @@ my $app = sub {
   if ($rendered) {
     $response->status(200);
     $response->body($rendered);
-
-    return $response->finalize;
   } else {
     $response->status(500);
     $response->body("# metrics rendering failed");
-
-    return $response->finalize;
   }
+
+  return $response->finalize;
 
 };

--- a/bin/metrics_exporter.pl
+++ b/bin/metrics_exporter.pl
@@ -1,0 +1,30 @@
+use HTFeed::JobMetrics;
+use Plack::Response;
+
+# Metrics exporter for prometheus statistics gathered via ingest.
+# Usage: plackup -p 9090 ./bin/metrics_exporter.pl
+
+my $metrics = HTFeed::JobMetrics->get_instance();
+
+my $app = sub {
+  my $env = shift;
+
+  my $rendered = $metrics->pretty();
+  my $headers = { "Content-Type" => "text/plain" };
+
+  my $response = Plack::Response->new();
+  $response->content_type('text/plain');
+
+  if ($rendered) {
+    $response->status(200);
+    $response->body($rendered);
+
+    return $response->finalize;
+  } else {
+    $response->status(500);
+    $response->body("# metrics rendering failed");
+
+    return $response->finalize;
+  }
+
+};

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,6 +76,7 @@ services:
       - HTFEED_CONFIG=/usr/local/feed/etc/config_ingest_docker.yml
       - FEED_HOME=/usr/local/feed
       - VERSION=feed-development
+      - HTFEED_JOBMETRICS_DATA_DIR=/usr/local/feed/jobmetrics
     depends_on:
       mariadb: *healthy
 
@@ -86,11 +87,26 @@ services:
       - ./volumes_to_test:/tmp/stage/toingest/test
     environment:
       - HTFEED_CONFIG=/usr/local/feed/etc/config_prevalidate.yml
+      - HTFEED_JOBMETRICS_DATA_DIR=/usr/local/feed/jobmetrics
       - FEED_HOME=/usr/local/feed
       - VERSION=feed-development
     command: bash -c "/bin/ls /tmp/stage/toingest/test/*.zip | xargs -n 1 basename | sed s/.zip// | perl -w /usr/local/feed/bin/validate_volume.pl -p simple -n test --no-clean"
     depends_on:
       mariadb: *healthy
+
+  prometheus-exporter:
+    build: .
+    volumes:
+      - .:/usr/local/feed
+    ports:
+      - "9090:9090"
+    environment:
+      - HTFEED_CONFIG=/usr/local/feed/etc/config_prevalidate.yml
+      - HTFEED_JOBMETRICS_DATA_DIR=/usr/local/feed/jobmetrics
+      - FEED_HOME=/usr/local/feed
+      - VERSION=feed-development
+    command: plackup -p 9090 ./bin/metrics_exporter.pl
+
 
   mariadb:
     image: ghcr.io/hathitrust/db-image:latest
@@ -124,6 +140,7 @@ services:
     healthcheck:
       <<: *healthcheck-defaults
       test: [ "CMD", "wget", "--quiet", "--tries=1", "-O", "/dev/null", "pushgateway:9091/-/healthy" ]
+
 
   rabbitmq:
     image: rabbitmq


### PR DESCRIPTION
This adds a very simple plack application which we can run as a sidecar container for the ingest workers that will allow the metrics to be scraped.

To see it in action/test it locally:

```
docker compose up prometheus-exporter
curl http://localhost:9090 # should see the metric names
cp t/fixtures/simple/test/*.zip volumes_to_test # or put anything else in volumes_to_test
docker compose run validate
curl http://localhost:9090 # should see some values for some metrics
```