### PR TITLE
DEV-1232: unbreak ingest_status.pl

### DIFF
--- a/bin/ingest_status.pl
+++ b/bin/ingest_status.pl
@@ -1,115 +1,86 @@
 #!/usr/bin/perl
 
-use warnings;
-use strict;
-
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 
-use Getopt::Long    qw(:config no_ignore_case);
-use HTFeed::DBTools qw(get_dbh);
+use warnings;
+use strict;
 use HTFeed::Log { root_logger => 'INFO, screen' };
 use HTFeed::Version;
+use HTFeed::DBTools qw(get_dbh);
 use HTFeed::Volume;
+use Getopt::Long qw(:config no_ignore_case);
 use Pod::Usage;
 
-my $one_line   = 0; # -1
-my $verbose    = 0; # -v
-my $quiet      = 0; # -q
-my $status     = undef; # -s
+my $one_line = 0; # -1
+my $verbose = 0; # -v
+my $quiet = 0; # -q
+my $status = undef; # -s
 my $not_status = undef; # -S
-my $help       = 0; # -help,-?
-my $dot        = 0;
+my $help = 0; # -help,-?
+my $dot = 0;
+
 my $default_namespace = undef; # -n
 
 # read flags
 GetOptions(
-    '1'              => \$one_line,
-    'verbose|v'      => \$verbose,
-    'status|s=s'     => \$status,
+    '1' => \$one_line,
+    'verbose|v' => \$verbose,
+    'status|s=s' => \$status,
     'not-status|S=s' => \$not_status,
-    'quiet|q'        => \$quiet,
-    'dot|d'          => \$dot,
-    'help|?'         => \$help,
-    'namespace|n=s'  => \$default_namespace,
-) or pod2usage(2);
+    'quiet|q' => \$quiet,
+    'dot|d' => \$dot,
+    'help|?' => \$help,
+    'namespace|n=s' => \$default_namespace,
+)  or pod2usage(2);
 
 pod2usage(1) if $help;
 
 # check options
-if ($default_namespace) and ($one_line or $dot) {
-    pod2usage(
-	-msg     => '-n excludes -d and -1',
-	-exitval => 2
-    );
-}
+pod2usage(-msg => '-n excludes -d and -1', -exitval => 2) if ($default_namespace) and ($one_line or $dot);
 
 my @volumes;
 
 # handle -1 flag (no infile read, get one object form command line)
-if ($one_line and $dot) {
+if($one_line and $dot) {
     my $htid = shift @ARGV;
     my ($namespace, $objid) = parse_htid($htid);
-    push (
-	@volumes,
-	HTFeed::Volume->new(
-	    packagetype => 'ht',
-	    namespace   => $namespace,
-	    objid       => $objid
-	)
-    );
-} elsif ($one_line) {
+    push @volumes, HTFeed::Volume->new(packagetype => 'ht', namespace => $namespace, objid => $objid);
+}
+elsif ($one_line) {
     my $namespace = shift @ARGV;
-    my $objid     = shift @ARGV;
-    unless ($namespace and $objid) {
+    my $objid = shift @ARGV;
+    unless( $namespace and $objid ){
         die 'Must specify namespace and objid when using -1 option';
     }
-    push(
-	@volumes,
-	HTFeed::Volume->new(
-	    packagetype => 'ht',
-	    namespace   => $namespace,
-	    objid       => $objid
-	)
-    );
-} else {
+
+    push @volumes, HTFeed::Volume->new(packagetype => 'ht', namespace => $namespace, objid => $objid);
+}
+else{
     # handle -d (read infile in dot format)
     if ($dot) {
         while (my $htid = <>) {
-            my ($namespace, $objid) = parse_htid($htid);
-            push(
-		@volumes,
-		HTFeed::Volume->new(
-		    packagetype => 'ht',
-		    namespace   => $namespace,
-		    objid       => $objid
-		)
-	    );
+            my ($namespace,$objid) = parse_htid($htid);
+
+            push @volumes, HTFeed::Volume->new(packagetype => 'ht', namespace => $namespace, objid => $objid);
         }
     }
 
     # handle default case (read infile in standard format)
-    if (!$dot) {
+    if (! $dot) {
         while (<>) {
             next if ($_ =~ /^\s*$/); # skip blank line
-            my @words     = split;
-            my $objid     = pop @words;
+            my @words = split;
+            my $objid = pop @words;
             my $namespace = (pop @words or $default_namespace);
 
             die("namespace missing (specify with -n) (objid was $objid)\n") if not defined $namespace;
             next if !$objid;
 
             eval {
-                push(
-		    @volumes,
-		    HTFeed::Volume->new(
-			packagetype => 'ht',
-			namespace   => $namespace,
-			objid       => $objid
-		    )
-		);
+                push @volumes, HTFeed::Volume->new(packagetype => 'ht', namespace => $namespace, objid => $objid);
             };
-            if ($@) {
+            if($@) {
                 warn($@);
             }
         }
@@ -117,53 +88,55 @@ if ($one_line and $dot) {
 }
 
 my $dbh = get_dbh();
-my $log_sth        = $dbh->prepare("select * from feed_log where namespace = ? and id = ? order by timestamp asc");
-my $last_err_sth   = $dbh->prepare("select * from feed_last_error where namespace = ? and id = ?");
-my $queue_sth      = $dbh->prepare("select * from feed_queue where namespace = ? and id = ?");
+
+my $log_sth = $dbh->prepare("select * from feed_log where namespace = ? and id = ? order by timestamp asc");
+my $last_err_sth = $dbh->prepare("select * from feed_last_error where namespace = ? and id = ?");
+my $queue_sth = $dbh->prepare("select * from feed_queue where namespace = ? and id = ?");
 my $queue_done_sth = $dbh->prepare("select * from feed_queue_done where namespace = ? and id = ?");
 
 foreach my $volume (@volumes) {
+
     my $namespace = $volume->get_namespace();
-    my $objid     = $volume->get_objid();
-    $queue_sth->execute($namespace, $objid);
-    $queue_done_sth->execute($namespace, $objid);
-    my $queue_info      = $queue_sth->fetchrow_hashref();
+    my $objid = $volume->get_objid();
+
+    $queue_sth->execute($namespace,$objid);
+    my $queue_info = $queue_sth->fetchrow_hashref();
+    $queue_done_sth->execute($namespace,$objid);
     my $queue_done_info = $queue_done_sth->fetchrow_hashref();
 
-    if (not defined $queue_info) {
-	if (defined $queue_done_info) {
-	    $queue_info = $queue_done_info;
-	    $queue_info->{status} = 'done';
-	} else {
-	    print "$namespace.$objid: not in queue\n" ;
-	    next;
-	}
+    if(not defined $queue_info) {
+      if(defined $queue_done_info) {
+        $queue_info = $queue_done_info;
+        $queue_info->{status} = 'done';
+      } else {
+        print "$namespace.$objid: not in queue\n" ;
+        next;
+      }
     }
 
-    next unless !$status     or ($status     eq $queue_info->{status});
-    next unless !$not_status or ($not_status ne $queue_info->{status});
+    next unless !$status or $status eq $queue_info->{status};
+    next unless !$not_status or $not_status ne $queue_info->{status};
 
     print "$namespace.$objid: $queue_info->{pkg_type}; $queue_info->{status}";
 
-    if ($quiet) {
-	print "\n";
-    } else {
+    if(!$quiet) {
         my $err_sth;
         print " at $queue_info->{update_stamp}\n" if(!$quiet);
 
-        if ($verbose) {
+        if($verbose) {
             $err_sth = $log_sth;
-        } elsif ($queue_info->{status} eq 'punted') {
+        }
+        elsif($queue_info->{status} eq 'punted') {
             $err_sth = $last_err_sth;
         }
 
-        if (defined $err_sth) {
-            $err_sth->execute($namespace, $objid);
-            while (my $row = $err_sth->fetchrow_hashref()) {
+        if(defined $err_sth) {
+            $err_sth->execute($namespace,$objid);
+            while(my $row = $err_sth->fetchrow_hashref()) {
                 print "  ";
                 delete $row->{namespace};
                 delete $row->{id};
-                if ($verbose) {
+                if($verbose) {
                     print "$row->{timestamp} $row->{level}: ";
                 }
                 delete $row->{timestamp};
@@ -173,24 +146,28 @@ foreach my $volume (@volumes) {
                 print "$row->{detail}; " if defined $row->{detail} and $row->{detail};
                 delete $row->{detail};
                 foreach my $key (sort(keys(%$row))) {
+
                     next if not defined $row->{$key} or $row->{$key} eq '';
                     print "$key: $row->{$key}; ";
                 }
                 print "\n";
             }
         }
+    } else {
+        print "\n";
     }
+
 }
 
 sub parse_htid {
     my $htid = shift;
     # simplified, lines should match /(.*)\.(.*)/
     $htid =~ /^([^\.\s]*)\.([^\s]*)$/;
-    my ($namespace, $objid) = ($1, $2);
-    unless ($namespace and $objid) {
+    my ($namespace,$objid) = ($1,$2);
+    unless( $namespace and $objid ){
         die "Bad syntax near: $htid";
     }
-    return($namespace, $objid);
+    return($namespace,$objid);
 }
 
 __END__
@@ -230,5 +207,5 @@ ingest_status.pl [-v|-q] -1 namespace objid
 
     dot-style (-d) infile rows:
         namespace.objid
-
 =cut
+


### PR DESCRIPTION
I can't quickly tell what's wrong with the tidy version, so reverting to untidy version, which is at least error free.

Tidy version, broken:
```
$ git checkout b92716d -- bin/ingest_status.pl
...
$ perl -c bin/ingest_status.pl 
syntax error at bin/ingest_status.pl line 40, near ") and"
Can't redeclare "my" in "my" at bin/ingest_status.pl line 51, near "my"
Global symbol "@volumes" requires explicit package name (did you forget to declare "my @volumes"?) at bin/ingest_status.pl line 54.
Global symbol "@volumes" requires explicit package name (did you forget to declare "my @volumes"?) at bin/ingest_status.pl line 68.
Global symbol "@volumes" requires explicit package name (did you forget to declare "my @volumes"?) at bin/ingest_status.pl line 81.
Global symbol "@volumes" requires explicit package name (did you forget to declare "my @volumes"?) at bin/ingest_status.pl line 104.
bin/ingest_status.pl had compilation errors.
```

Previous, untidy version, works:
```
$ git checkout 042f52f -- bin/ingest_status.pl
...
$ perl -c bin/ingest_status.pl 
bin/ingest_status.pl syntax OK
```