### PR TITLE
DEV-1239: pinned RabbitMQ to the last working version

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -22,7 +22,7 @@ WriteMakefile(
     'Mail::Mailer'        => 0,
     'METS'                => 0,
     'Mouse'               => 0,
-    'Net::AMQP::RabbitMQ' => 0,
+    'Net::AMQP::RabbitMQ' => "== 2.40010",
     'Net::Prometheus'     => 0,
     'Prometheus::Tiny::Shared' => 0,
     'ProgressTracker'     => 0,


### PR DESCRIPTION
Originating ticket: https://hathitrust.atlassian.net/browse/DEV-1239

This is a temporary solution.
The last working version is 2.40010.

In the long run, we need to figure out how to update dependencies for the latest version (2.40011) to work, but that's a separate task.

Reviewer: Verify that the docker image builds and tests run.