### PR TITLE
🐇: Improve bunnies test suite

### DIFF
--- a/t/lib/HTFeed/Test/SpecSupport.pm
+++ b/t/lib/HTFeed/Test/SpecSupport.pm
@@ -12,9 +12,14 @@ use HTFeed::Test::Logger;
 use HTFeed::Test::TempDirs;
 use Exporter 'import';
 
+use constant {
+  # Value to pass to RabbitMQ to tell it not to block if the message queue is empty
+  NO_WAIT => -1,
+  # Amount of time to wait (in milliseconds) if we expect there will be a message eventually
+  RECV_WAIT => 500
+};
+
 our @EXPORT_OK = qw(mock_zephir mock_clamav stage_volume NO_WAIT RECV_WAIT);
-use constant NO_WAIT   => -1;
-use constant RECV_WAIT => 500;
 
 sub mock_zephir {
     no warnings 'redefine';

--- a/t/lib/HTFeed/Test/SpecSupport.pm
+++ b/t/lib/HTFeed/Test/SpecSupport.pm
@@ -1,35 +1,35 @@
 package HTFeed::Test::SpecSupport;
 
+use warnings;
+use strict;
+
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 
 # support for Test::Spec tests
 use HTFeed;
 use HTFeed::Test::Logger;
-
 use HTFeed::Test::TempDirs;
-
-use warnings;
-use strict;
 use Exporter 'import';
 
-our @EXPORT_OK = qw(mock_zephir mock_clamav stage_volume);
+our @EXPORT_OK = qw(mock_zephir mock_clamav stage_volume NO_WAIT RECV_WAIT);
+use constant NO_WAIT   => -1;
+use constant RECV_WAIT => 500;
 
 sub mock_zephir {
-  no warnings 'redefine';
-  *HTFeed::Volume::get_sources = sub {
-    return ( 'ht_test','ht_test','ht_test' );
-  };
+    no warnings 'redefine';
+    *HTFeed::Volume::get_sources = sub {
+        return ( 'ht_test','ht_test','ht_test' );
+    };
 
-  # use faked-up marc in case it's missing
+    # use faked-up marc in case it's missing
 
-  *HTFeed::SourceMETS::_get_marc_from_zephir = sub {
-    my $self = shift;
-    my $marc_path = shift;
+    *HTFeed::SourceMETS::_get_marc_from_zephir = sub {
+        my $self      = shift;
+        my $marc_path = shift;
 
-    open(my $fh, ">$marc_path") or die("Can't open $marc_path: $!");
-
-    print $fh <<EOT;
+        open(my $fh, ">$marc_path") or die("Can't open $marc_path: $!");
+        print $fh <<EOT;
 <?xml version="1.0" encoding="UTF-8"?>
 <collection xmlns="http://www.loc.gov/MARC21/slim">
 <record>
@@ -38,32 +38,35 @@ sub mock_zephir {
 </collection>
 EOT
 
-    close($fh);
+        close($fh);
+    };
 
-  };
-
-  use warnings 'redefine';
+    use warnings 'redefine';
 }
 
 sub mock_clamav {
-  use HTFeed::Test::MockClamAV;
+    use HTFeed::Test::MockClamAV;
 
-  return HTFeed::Test::MockClamAV->new();
+    return HTFeed::Test::MockClamAV->new();
 }
 
 sub stage_volume {
-  my $tmpdirs = shift;
-  my $namespace = shift;
-  my $objid = shift;
+    my $tmpdirs   = shift;
+    my $namespace = shift;
+    my $objid     = shift;
 
-  my $mets = $tmpdirs->test_home . "/fixtures/volumes/$objid.mets.xml";
-  my $zip = $tmpdirs->test_home . "/fixtures/volumes/$objid.zip";
-  system("cp $mets $tmpdirs->{ingest}");
-  mkdir("$tmpdirs->{zipfile}/$objid");
-  system("cp $zip $tmpdirs->{zipfile}/$objid");
+    my $mets = $tmpdirs->test_home . "/fixtures/volumes/$objid.mets.xml";
+    my $zip  = $tmpdirs->test_home . "/fixtures/volumes/$objid.zip";
 
-  my $volume = HTFeed::Volume->new(
-    namespace => $namespace,
-    objid => $objid,
-    packagetype => 'simple');
+    system("cp $mets $tmpdirs->{ingest}");
+    mkdir("$tmpdirs->{zipfile}/$objid");
+    system("cp $zip $tmpdirs->{zipfile}/$objid");
+
+    my $volume = HTFeed::Volume->new(
+        namespace   => $namespace,
+        objid       => $objid,
+        packagetype => 'simple'
+    );
 }
+
+1;

--- a/t/queue.t
+++ b/t/queue.t
@@ -2,7 +2,7 @@ use FindBin;
 use lib "$FindBin::Bin/lib";
 use Test::Spec;
 use Test::Exception;
-use HTFeed::Test::SpecSupport;
+use HTFeed::Test::SpecSupport qw(NO_WAIT RECV_WAIT);
 
 use HTFeed::Config qw(get_config);
 use HTFeed::DBTools qw(get_dbh);
@@ -10,9 +10,6 @@ use HTFeed::Bunnies;
 use HTFeed::Queue;
 
 use strict;
-
-my $NO_WAIT = -1;
-my $RECV_WAIT = 500; # RabbitMQ recv timeout in milliseconds
 
 describe "HTFeed::Queue" => sub {
   my $testlog;
@@ -45,7 +42,7 @@ describe "HTFeed::Queue" => sub {
     my $volume = shift;
     my $status = shift;
 
-    my $job = HTFeed::Bunnies->new()->next_job($RECV_WAIT);
+    my $job = HTFeed::Bunnies->new()->next_job(RECV_WAIT);
     is($job->{pkg_type},  $volume->get_packagetype);
     is($job->{namespace}, $volume->get_namespace);
     is($job->{id},        $volume->get_objid);
@@ -85,7 +82,7 @@ describe "HTFeed::Queue" => sub {
         my $priority = HTFeed::Queue::QUEUE_PRIORITY_MED;
 
         HTFeed::Queue->new->enqueue(volume => testvolume, status => 'ready', priority => $priority);
-        my $job = HTFeed::Bunnies->new()->next_job($RECV_WAIT);
+        my $job = HTFeed::Bunnies->new()->next_job(RECV_WAIT);
 
         is($job->{msg}{props}{priority}, $priority);
       };
@@ -119,7 +116,7 @@ describe "HTFeed::Queue" => sub {
           $receiver->reset_queue;
 
           HTFeed::Queue->new->enqueue(volume => testvolume, status => 'ready', ignore => 1);
-          ok(!$receiver->next_job($RECV_WAIT));
+          ok(!$receiver->next_job(RECV_WAIT));
 
         }
       };
@@ -139,7 +136,7 @@ describe "HTFeed::Queue" => sub {
           $receiver->reset_queue;
 
           HTFeed::Queue->new->enqueue(volume => testvolume, status => 'ready', ignore => 1);
-          ok(!$receiver->next_job($RECV_WAIT));
+          ok(!$receiver->next_job(RECV_WAIT));
 
         }
       };
@@ -160,7 +157,7 @@ describe "HTFeed::Queue" => sub {
         it "doesn't add a message to the queue" => sub {
           HTFeed::Queue->new->enqueue(volume=>testvolume, status=>'ready');
 
-          ok(!HTFeed::Bunnies->new->next_job($RECV_WAIT));
+          ok(!HTFeed::Bunnies->new->next_job(RECV_WAIT));
         };
         it "doesn't put the item in the database" => sub {
           HTFeed::Queue->new->enqueue(volume=>testvolume, status=>'ready');
@@ -213,7 +210,7 @@ describe "HTFeed::Queue" => sub {
         it "doesn't put the item in the message queue" => sub {
           HTFeed::Queue->new->enqueue(volume=>testvolume, status=>'ready');
           
-          ok(!HTFeed::Bunnies->new->next_job($RECV_WAIT));
+          ok(!HTFeed::Bunnies->new->next_job(RECV_WAIT));
         };
       };
 
@@ -261,7 +258,7 @@ describe "HTFeed::Queue" => sub {
         $queue->enqueue(volume=>testvolume, status=>'punted');
         $queue->reset(volume=>testvolume, reset_level => 1, priority => $priority);
 
-        my $job = HTFeed::Bunnies->new()->next_job($RECV_WAIT);
+        my $job = HTFeed::Bunnies->new()->next_job(RECV_WAIT);
         is($job->{msg}{props}{priority}, $priority);
       };
 
@@ -282,7 +279,7 @@ describe "HTFeed::Queue" => sub {
         $queue->enqueue(volume=>testvolume, status=>'done');
         $queue->reset(volume=>testvolume, reset_level => 1);
         ok(!volume_in_feed_queue(testvolume, 'ready'));
-        ok(!HTFeed::Bunnies->new->next_job($RECV_WAIT));
+        ok(!HTFeed::Bunnies->new->next_job(RECV_WAIT));
       };
 
       describe "when resetting to available state" => sub {
@@ -297,7 +294,7 @@ describe "HTFeed::Queue" => sub {
           my $queue = HTFeed::Queue->new;
           $queue->enqueue(volume=>testvolume, status=>'punted');
           $queue->reset(volume=>testvolume, reset_level => 1, status=>'available');
-          ok(!HTFeed::Bunnies->new->next_job($RECV_WAIT));
+          ok(!HTFeed::Bunnies->new->next_job(RECV_WAIT));
         };
       };
     };
@@ -326,7 +323,7 @@ describe "HTFeed::Queue" => sub {
 
         $queue->reset(volume=>testvolume, reset_level => 2);
         ok(!volume_in_feed_queue(testvolume, 'ready'));
-        ok(!HTFeed::Bunnies->new->next_job($RECV_WAIT));
+        ok(!HTFeed::Bunnies->new->next_job(RECV_WAIT));
       };
     };
 
@@ -370,7 +367,7 @@ describe "HTFeed::Queue" => sub {
         HTFeed::Bunnies->new->reset_queue;
         
         $queue->reset(volume=>testvolume, reset_level => 3, status => 'ready');
-        my $job = HTFeed::Bunnies->new()->next_job($RECV_WAIT);
+        my $job = HTFeed::Bunnies->new()->next_job(RECV_WAIT);
         is($job->{msg}{props}{priority}, $priority);
       };
     };
@@ -386,7 +383,7 @@ describe "HTFeed::Queue" => sub {
 
     it "with available status, does not send a message" => sub {
       HTFeed::Queue->new->send_to_message_queue(testvolume,'available');
-      ok(!HTFeed::Bunnies->new->next_job($RECV_WAIT));
+      ok(!HTFeed::Bunnies->new->next_job(RECV_WAIT));
     };
   };
 

--- a/t/queue_runner.t
+++ b/t/queue_runner.t
@@ -2,7 +2,7 @@ use FindBin;
 use lib "$FindBin::Bin/lib";
 use Test::Spec;
 use Test::Exception;
-use HTFeed::Test::SpecSupport qw(mock_zephir);
+use HTFeed::Test::SpecSupport qw(mock_zephir NO_WAIT RECV_WAIT);
 use HTFeed::Test::Support qw(load_db_fixtures);
 use HTFeed::Config qw(get_config set_config);
 use HTFeed::DBTools qw(get_dbh);
@@ -11,9 +11,6 @@ use HTFeed::Queue;
 use HTFeed::QueueRunner;
 
 use strict;
-
-my $NO_WAIT = -1;
-my $RECV_WAIT = 500;
 
 describe "HTFeed::QueueRunner" => sub {
   local our ($tmpdirs, $testlog);
@@ -58,11 +55,11 @@ describe "HTFeed::QueueRunner" => sub {
   }
 
   sub no_messages_in_queue {
-    not defined HTFeed::Bunnies->new()->next_job($NO_WAIT);
+    not defined HTFeed::Bunnies->new()->next_job(NO_WAIT);
   }
 
   sub queue_runner {
-    HTFeed::QueueRunner->new(timeout => $RECV_WAIT, should_fork => 0, clean => 0);
+    HTFeed::QueueRunner->new(timeout => RECV_WAIT, should_fork => 0, clean => 0);
   }
 
   before all => sub {


### PR DESCRIPTION
Fixes #133

* Add helper functions to clarify purposes of tests
* Fixes semantics of one currently-brittle test to ensure that we wait for a message when we expect there to be one
* Test what we say we're testing when expecting to get a particular job
* Makes NO_WAIT and RECV_WAIT constants