### PR TITLE
BUG: math off by 1, corrected

### DIFF
--- a/lib/HTFeed/Stage/ImageRemediate.pm
+++ b/lib/HTFeed/Stage/ImageRemediate.pm
@@ -862,7 +862,7 @@ sub expand_other_file_formats {
 	my $infile     = "$path/$file";
         my @parts      = fileparse($infile, @other_recognized_formats);
         my $outname    = $parts[0];
-        my $ext        = $parts[1];
+        my $ext        = $parts[2];
 	my $outfile    = "$path/$outname.tif";
         my $start_time = $self->{job_metrics}->time;
 	my $cmd        = "$imagemagick_cmd -compress None $infile -strip $outfile";


### PR DESCRIPTION
Messed up the last feed release, but didn't realize until running action on feed_internal.

My original bad math change:

```diff
- my ($outname, undef, $ext) = fileparse($infile, @other_recognized_formats);
+ my @parts      = fileparse($infile, @other_recognized_formats);
+ my $outname    = $parts[0];
+ my $ext        = $parts[1];
```
The actual good math change:

```diff
- my ($outname, undef, $ext) = fileparse($infile, @other_recognized_formats);
+ my @parts      = fileparse($infile, @other_recognized_formats);
+ my $outname    = $parts[0];
+ my $ext        = $parts[2]; # 2 not 1
```