### PR TITLE
Dev 1253 whitebalance

### DIFF
--- a/bin/validate_volume.sh
+++ b/bin/validate_volume.sh
@@ -1,0 +1,12 @@
+# bash validate_volume.sh /path/to/item.zip
+
+fullpath=$(realpath $1)
+objid=$(basename $fullpath .zip)
+test_dir=/tmp/prep/toingest/test/
+
+# Set up working dir and copy input file there
+rm    --verbose -rf "$test_dir"
+mkdir --verbose -p  "$test_dir"
+cp    --verbose     "$fullpath" "$test_dir"
+
+perl /usr/local/feed/bin/validate_volume.pl -1 simple test $objid --clean

--- a/lib/HTFeed/Stage/ImageRemediate.pm
+++ b/lib/HTFeed/Stage/ImageRemediate.pm
@@ -247,6 +247,7 @@ sub _remediate_tiff {
 	    my @imagemagick_remediable_errs = (
 		'PhotometricInterpretation not defined',
 		'ColorSpace value out of range: 2',
+		'WhiteBalance value out of range: 4',
 		'WhiteBalance value out of range: 5',
 		# wrong data type for tag - will get automatically stripped
 		'Type mismatch for tag',


### PR DESCRIPTION
Now when `ImageRemediate` sees a pagescan with `WhiteBalance=4` it'll try and be OK with it, rather than bail out of processing the item.

Added to `@imagemagick_remediable_errs` :
```
'WhiteBalance value out of range: 4',
```

In order to test it locally, I added yet another version of `validate_volume` : 

```
# Call from outside container
$ docker compose run --rm test bash bin/validate_volume.sh volumes_to_test/volume.zip

# Call from inside container
$ docker compose run --rm test bash 
ingest@bb3a99453802:~$ bash bin/validate_volume.sh volumes_to_test/volume.zip
```
I don't know what's up with the other `validate_volume` scripts, but I couldn't get them working.
I put together a test item at `/htprep/failed/test/whitebalance4.zip` rather than adding it to the repo.