### PR TITLE
DEV-1313 (Local ingest doesn't look for material in "failure" directory)

### DIFF
--- a/t/enqueue.t
+++ b/t/enqueue.t
@@ -1,0 +1,186 @@
+use strict;
+use warnings;
+
+use FindBin;
+use lib "$FindBin::Bin/lib";
+
+use HTFeed::Config qw(get_config);
+use HTFeed::DBTools qw(get_dbh);
+use HTFeed::Queue;
+use HTFeed::Volume;
+use Test::Exception;
+use Test::Spec;
+
+describe "bin/enqueue.pl" => sub {
+
+    sub testvolume {
+	HTFeed::Volume->new(
+	    packagetype => 'simple',
+	    namespace   => 'test',
+	    objid       => 'test'
+	);
+    }
+
+    sub fake_bibdata {
+	my $volume = shift;
+	my $sql = join(
+	    " ",
+	    "REPLACE INTO feed_zephir_items",
+	    "(namespace, id, collection, digitization_source, returned)",
+	    "VALUES",
+	    "(?,         ?,  'TEST',     'test',              '0')"
+	);
+	get_dbh()->do($sql, {}, $volume->get_namespace, $volume->get_objid);
+    }
+
+    sub enqueue_testvolume {
+	my %params = (
+	    # defaults
+	    volume => testvolume,
+	    status => "ready",
+	    # override defaults
+	    @_
+	);
+
+	return HTFeed::Queue->new->enqueue(%params);
+    }
+
+    sub get_vol_from_queue {
+	my $volume = shift || testvolume;
+	my $status = shift || "ready";
+
+	my $sql = join(
+	    " ",
+	    "SELECT *",
+	    "FROM   feed_queue",
+	    "WHERE  namespace = ?",
+	    "AND    id        = ?",
+	    "AND    pkg_type  = ?",
+	    "AND    status    = ?"
+	);
+
+	get_dbh()->selectrow_hashref(
+	    $sql,
+	    {},
+	    $volume->get_namespace,
+	    $volume->get_objid,
+	    $volume->get_packagetype,
+	    $status
+	);
+    }
+
+    # Run a commandline invocation and check output against provided rx
+    sub enqueue {
+        my $cmd                = shift;
+        my $match_rx           = shift;
+        my $expect_match_count = shift;
+	my $verbose            = shift || 0;
+
+        my $full_cmd = "perl bin/enqueue.pl $cmd";
+	my (undef, undef, $line) = caller;
+        print "Check output from command on line $line [$full_cmd] against rx [$match_rx]\n" if $verbose;
+
+        # Run command, capture output.
+	# Use double spaces to make it look good.
+        my @cmd_output = `$full_cmd`;
+	my $double_space = "  ";
+        print "Output:[\n$double_space" . join($double_space, @cmd_output) . "]\n" if $verbose;
+
+        # Check that the desired regex was found in the output
+        my $match_count = grep {$_ =~ $match_rx} @cmd_output;
+        print "Expected $match_rx match count: $expect_match_count, got $match_count\n" if $verbose;
+        ok($match_count == $expect_match_count);
+	print "\n" if $verbose;
+    }
+
+    before each => sub {
+        HTFeed::Bunnies->new()->reset_queue;
+        get_dbh()->do("DELETE FROM feed_queue");
+        get_dbh()->do("DELETE FROM feed_zephir_items");
+    };
+
+    it "won't queue if missing bib data" => sub {
+        enqueue(
+            '-v -i -1 simple test test',
+            qr/Missing bibliographic data/,
+            1
+        );
+    };
+    it "can queue if there is bib data" => sub {
+	fake_bibdata(testvolume);
+        enqueue(
+            '-v -i -1 simple test test',
+            qr/simple test test: queued/,
+            1
+        );
+    };
+    it "won't queue an item already in the queue using -i" => sub {
+	fake_bibdata(testvolume);
+	my $same_command = '-v -i -1 simple test test';
+        enqueue(
+            $same_command,
+            qr/simple test test: queued/,
+            1
+        );
+        enqueue(
+            $same_command,
+            qr/simple test test: failure or skipped/,
+            1
+        );
+    };
+    it "needs -r or -R to queue an item already in the queue" => sub {
+	fake_bibdata(testvolume);
+        enqueue_testvolume(status => 'punted');
+
+        # Need to specify -r or -R for it to work
+        enqueue(
+            '-v -r -1 simple test test',
+            qr/simple test test: reset/,
+            1
+        );
+        enqueue(
+            '-v -R -1 simple test test',
+            qr/simple test test: reset/,
+            1
+        );
+    };
+    it "uses -u to reuse punted items rather than re-download" => sub {
+	fake_bibdata(testvolume);
+	enqueue_testvolume(status => 'punted');
+
+	# -u to reuse a punted item,
+	# only works in combination with a reset flag (-r/-R).
+	# (in this case i'm also re-routing stderr to devnull,
+	# because i'm doing such a bad thing that enqueue.pl
+	# is going to print its whole pod2usage to stderr, and I don't want it)
+	enqueue(
+            '-v -u -1 simple test test 2>/dev/null',
+            qr/empty result/,
+            0
+        );
+
+	# This time with both -r and -u,
+	# but since things haven't run normally
+	# it won't find anything in the failed location
+	enqueue(
+            '-v -r -u -1 simple test test',
+            qr/can't find sip in ingest or failure location/,
+            1
+        );
+
+	# Make the failed location and put a volume there,
+	# and this time the punted item will be reused.
+	system("mkdir -p /tmp/prep/failed/test/");
+	system("cp /usr/local/feed/t/fixtures/volumes/test.zip /tmp/prep/failed/test/");
+	enqueue(
+	    '-v -r -u -1 simple test test',
+            qr/punted item reused/,
+            1
+        );
+
+	# clean up
+	system("rm -f /tmp/prep/toingest/test/test.zip /tmp/prep/failed/test/test.zip");
+    };
+};
+
+runtests unless caller;

--- a/t/queue.t
+++ b/t/queue.t
@@ -1,391 +1,397 @@
-use FindBin;
-use lib "$FindBin::Bin/lib";
-use Test::Spec;
-use Test::Exception;
-use HTFeed::Test::SpecSupport qw(NO_WAIT RECV_WAIT);
-
-use HTFeed::Config qw(get_config);
-use HTFeed::DBTools qw(get_dbh);
-use HTFeed::Bunnies;
-use HTFeed::Queue;
-
 use strict;
 
+use FindBin;
+use lib "$FindBin::Bin/lib";
+
+use HTFeed::Bunnies;
+use HTFeed::Config qw(get_config);
+use HTFeed::DBTools qw(get_dbh);
+use HTFeed::Queue;
+use HTFeed::Test::SpecSupport qw(NO_WAIT RECV_WAIT);
+use Test::Exception;
+use Test::Spec;
+
 describe "HTFeed::Queue" => sub {
-  my $testlog;
+    my $testlog;
 
-  before all => sub {
-    $testlog = HTFeed::Test::Logger->new();
-  };
-
-  before each => sub {
-    HTFeed::Bunnies->new()->reset_queue;
-    get_dbh()->do("DELETE FROM feed_queue");
-    get_dbh()->do("DELETE FROM feed_zephir_items");
-    get_dbh()->do("DELETE FROM feed_queue_disallow");
-    $testlog->reset;
-  };
-
-  sub fake_bibdata {
-    my $volume = shift;
-
-    get_dbh()->do("REPLACE INTO feed_zephir_items (namespace, id, collection, digitization_source, returned) values (?,?,'TEST','test','0')",{},$volume->get_namespace,$volume->get_objid);
-  }
-  
-  sub testvolume {
-    HTFeed::Volume->new(packagetype => 'simple', 
-      namespace => 'test', 
-      objid => 'test');
-  }
-
-  sub test_job_queued_for_volume {
-    my $volume = shift;
-    my $status = shift;
-
-    my $job = HTFeed::Bunnies->new()->next_job(RECV_WAIT);
-    is($job->{pkg_type},  $volume->get_packagetype);
-    is($job->{namespace}, $volume->get_namespace);
-    is($job->{id},        $volume->get_objid);
-    is($job->{status},    $status);
-  }
-
-  sub volume_in_feed_queue {
-    my $volume = shift;
-    my $status = shift;
-
-    get_dbh()->selectrow_hashref("SELECT * FROM feed_queue WHERE namespace = ? and id = ? and pkg_type = ? and status = ?",{},$volume->get_namespace,$volume->get_objid,$volume->get_packagetype,$status);
-
-  }
-
-  describe "enqueue" => sub {
-
-    describe "with a new item" => sub {
-      before each => sub { fake_bibdata(testvolume); };
-
-      it "returns true" => sub {
-        ok(HTFeed::Queue->new->enqueue(volume => testvolume, status => 'ready'));
-      };
-
-      it "puts the item in the database" => sub {
-        HTFeed::Queue->new->enqueue(volume => testvolume, status => 'ready');
-
-        ok(volume_in_feed_queue(testvolume, 'ready'));
-      };
-      
-      it "puts the item in the message queue" => sub {
-        HTFeed::Queue->new->enqueue(volume => testvolume, status => 'ready');
-
-        test_job_queued_for_volume(testvolume, 'ready');
-      };
-
-      it "accepts a priority" => sub {
-        my $priority = HTFeed::Queue::QUEUE_PRIORITY_MED;
-
-        HTFeed::Queue->new->enqueue(volume => testvolume, status => 'ready', priority => $priority);
-        my $job = HTFeed::Bunnies->new()->next_job(RECV_WAIT);
-
-        is($job->{msg}{props}{priority}, $priority);
-      };
-
-      it "records the priority in the feed_queue table" => sub {
-        my $priority = HTFeed::Queue::QUEUE_PRIORITY_HIGH;
-        HTFeed::Queue->new->enqueue(volume => testvolume, status => 'ready', priority => $priority);
-        is($priority,volume_in_feed_queue(testvolume, 'ready')->{priority});
-      };
+    before all => sub {
+	$testlog = HTFeed::Test::Logger->new();
     };
 
-    describe "with an item already in the queue" => sub {
-      before each => sub { 
-        fake_bibdata(testvolume);
-        HTFeed::Queue->new->enqueue(volume => testvolume, status => 'ready');
-      };
-
-      describe "without the ignore flag" => sub {
-
-        it "logs an error" => sub {
-          HTFeed::Queue->new->enqueue(volume => testvolume, status => 'ready');
-          ok($testlog->matches(qr(ERROR.*Duplicate)));
-        };
-
-        it "returns false" => sub {
-          ok(! HTFeed::Queue->new->enqueue(volume => testvolume, status => 'ready'));
-        };
-
-        it "doesn't add a message to the message queue" => sub {
-          my $receiver = HTFeed::Bunnies->new();
-          $receiver->reset_queue;
-
-          HTFeed::Queue->new->enqueue(volume => testvolume, status => 'ready', ignore => 1);
-          ok(!$receiver->next_job(RECV_WAIT));
-
-        }
-      };
-
-      describe "with the ignore flag" => sub {
-        it "returns false" => sub {
-          ok(! HTFeed::Queue->new->enqueue(volume => testvolume, status => 'ready', ignore => 1));
-        };
-
-        it "doesn't log an error" => sub {
-          HTFeed::Queue->new->enqueue(volume => testvolume, status => 'ready', ignore => 1);
-          ok(!$testlog->matches(qr(ERROR)));
-        };
-
-        it "doesn't add a message to the message queue" => sub {
-          my $receiver = HTFeed::Bunnies->new();
-          $receiver->reset_queue;
-
-          HTFeed::Queue->new->enqueue(volume => testvolume, status => 'ready', ignore => 1);
-          ok(!$receiver->next_job(RECV_WAIT));
-
-        }
-      };
-    };
-
-    describe "without bib data" => sub {
-      describe "without the no_bibdata_ok flag" => sub {
-        it "logs a warning" => sub {
-          HTFeed::Queue->new->enqueue(volume=>testvolume, status=>'ready');
-
-          ok($testlog->matches(qr(WARN.*bib.*data)));
-        };
-
-        it "returns false" => sub {
-          ok(!HTFeed::Queue->new->enqueue(volume=>testvolume, status=>'ready'));
-        };
-        
-        it "doesn't add a message to the queue" => sub {
-          HTFeed::Queue->new->enqueue(volume=>testvolume, status=>'ready');
-
-          ok(!HTFeed::Bunnies->new->next_job(RECV_WAIT));
-        };
-        it "doesn't put the item in the database" => sub {
-          HTFeed::Queue->new->enqueue(volume=>testvolume, status=>'ready');
-
-          ok(!volume_in_feed_queue(testvolume, 'ready'));
-        };
-      };
-
-      describe "with the no_bibdata_ok flag" => sub {
-        it "returns true" => sub {
-          ok(HTFeed::Queue->new->enqueue(volume=>testvolume, status=>'ready', no_bibdata_ok=>1));
-        };
-        it "puts the item in the database" => sub {
-          HTFeed::Queue->new->enqueue(volume => testvolume, status => 'ready', no_bibdata_ok=>1);
-
-          ok(volume_in_feed_queue(testvolume, 'ready'));
-        };
-        
-        it "puts the item in the message queue" => sub {
-          HTFeed::Queue->new->enqueue(volume => testvolume, status => 'ready', no_bibdata_ok=>1);
- 
-          test_job_queued_for_volume(testvolume, 'ready');
-        };
-      };
-    };
-
-    describe "with a disallowed item" => sub {
-      before each => sub {
-        fake_bibdata(testvolume);
-        get_dbh()->do("INSERT INTO feed_queue_disallow VALUES ('test','test','disallow test item',CURRENT_TIMESTAMP)");
-      };
-
-      context "with default use_disallow_list" => sub {
-        it "logs a warning" => sub {
-          HTFeed::Queue->new->enqueue(volume=>testvolume, status=>'ready');
-
-          ok($testlog->matches(qr(WARN.*disallow)));
-        };
-
-        it "returns false" => sub {
-          ok(!HTFeed::Queue->new->enqueue(volume=>testvolume, status => 'ready'));
-        };
-
-        it "doesn't put the item in the database" => sub {
-          HTFeed::Queue->new->enqueue(volume=>testvolume, status=>'ready');
-
-          ok(!volume_in_feed_queue(testvolume, 'ready'));
-        };
-
-        it "doesn't put the item in the message queue" => sub {
-          HTFeed::Queue->new->enqueue(volume=>testvolume, status=>'ready');
-          
-          ok(!HTFeed::Bunnies->new->next_job(RECV_WAIT));
-        };
-      };
-
-      context "with use_disallow_list = 0" => sub {
-        it "returns true" => sub {
-          ok(HTFeed::Queue->new->enqueue(volume=>testvolume, status => 'ready', use_disallow_list => 0));
-        };
-
-        it "puts the item in the database" => sub {
-          HTFeed::Queue->new->enqueue(volume=>testvolume, status=>'ready', use_disallow_list => 0);
-
-          ok(volume_in_feed_queue(testvolume, 'ready'));
-        };
-
-        it "puts the item in the message queue" => sub {
-          HTFeed::Queue->new->enqueue(volume=>testvolume, status=>'ready', use_disallow_list => 0);
-          
-          test_job_queued_for_volume(testvolume,'ready');
-        };
-      };
-    };
-  };
-
-  describe "reset" => sub {
     before each => sub {
-      fake_bibdata(testvolume);
+	HTFeed::Bunnies->new()->reset_queue;
+	get_dbh()->do("DELETE FROM feed_queue");
+	get_dbh()->do("DELETE FROM feed_zephir_items");
+	get_dbh()->do("DELETE FROM feed_queue_disallow");
+	$testlog->reset;
     };
 
-    it "requires reset level argument" => sub {
-      HTFeed::Queue->new->enqueue(volume=>testvolume, status=>'punted');
-      throws_ok { HTFeed::Queue->new->reset(volume => testvolume) } qr(Reset level)
+    sub fake_bibdata {
+	my $volume = shift;
+	my $sql = join(
+	    " ",
+	    "REPLACE INTO feed_zephir_items",
+	    "(namespace, id, collection, digitization_source, returned)",
+	    "VALUES",
+	    "(?,         ?,  'TEST',     'test',              '0')"
+	);
+	get_dbh()->do($sql, {}, $volume->get_namespace, $volume->get_objid);
+    }
+
+    sub testvolume {
+	HTFeed::Volume->new(
+	    packagetype => 'simple',
+	    namespace   => 'test',
+	    objid       => 'test'
+	);
+    }
+
+    sub enqueue_testvolume {
+	my %params = (
+	    # defaults
+	    volume => testvolume,
+	    status => "ready",
+	    # override defaults
+	    @_
+	);
+
+	return HTFeed::Queue->new->enqueue(%params);
+    }
+
+    sub is_testvolume_ready {
+	my $volume = testvolume;
+	my $status = "ready";
+	my $job    = HTFeed::Bunnies->new()->next_job(RECV_WAIT);
+
+	is($job->{pkg_type},  $volume->get_packagetype);
+	is($job->{namespace}, $volume->get_namespace);
+	is($job->{id},        $volume->get_objid);
+	is($job->{status},    $status);
+    }
+
+    sub get_vol_from_queue {
+	my $volume = shift || testvolume;
+	my $status = shift || "ready";
+
+	my $sql = join(
+	    " ",
+	    "SELECT *",
+	    "FROM   feed_queue",
+	    "WHERE  namespace = ?",
+	    "AND    id        = ?",
+	    "AND    pkg_type  = ?",
+	    "AND    status    = ?"
+	);
+
+	get_dbh()->selectrow_hashref(
+	    $sql,
+	    {},
+	    $volume->get_namespace,
+	    $volume->get_objid,
+	    $volume->get_packagetype,
+	    $status
+	);
+    }
+
+    sub queue_reset {
+	HTFeed::Queue->new->reset(
+	    # defaults
+	    volume      => testvolume,
+	    reset_level => 1,
+	    # override defaults
+	    @_
+	);
+    }
+
+    describe "enqueue" => sub {
+	describe "with a new item" => sub {
+	    before each => sub {
+		fake_bibdata(testvolume);
+	    };
+
+	    it "returns true" => sub {
+		ok(enqueue_testvolume);
+	    };
+
+	    it "puts the item in the database" => sub {
+		enqueue_testvolume;
+		ok(get_vol_from_queue);
+	    };
+
+	    it "puts the item in the message queue" => sub {
+		enqueue_testvolume;
+		is_testvolume_ready();
+	    };
+
+	    it "accepts a priority" => sub {
+		my $priority = HTFeed::Queue::QUEUE_PRIORITY_MED;
+		enqueue_testvolume(priority => $priority);
+		my $job = HTFeed::Bunnies->new()->next_job(RECV_WAIT);
+		is($job->{msg}{props}{priority}, $priority);
+	    };
+
+	    it "records the priority in the feed_queue table" => sub {
+		my $priority = HTFeed::Queue::QUEUE_PRIORITY_HIGH;
+		enqueue_testvolume(priority => $priority);
+		is($priority, get_vol_from_queue(testvolume, 'ready')->{priority});
+	    };
+	};
+
+	describe "with an item already in the queue" => sub {
+	    before each => sub {
+		fake_bibdata(testvolume);
+		enqueue_testvolume;
+	    };
+
+	    describe "without the ignore flag" => sub {
+		it "logs an error" => sub {
+		    enqueue_testvolume;
+		    ok($testlog->matches(qr(ERROR.*Duplicate)));
+		};
+
+		it "returns false" => sub {
+		    ok(!enqueue_testvolume);
+		};
+
+		it "doesn't add a message to the message queue" => sub {
+		    my $receiver = HTFeed::Bunnies->new();
+		    $receiver->reset_queue;
+		    enqueue_testvolume(ignore => 1);
+		    ok(!$receiver->next_job(RECV_WAIT));
+		}
+	    };
+
+	    describe "with the ignore flag" => sub {
+		it "returns false" => sub {
+		    ok(!enqueue_testvolume(ignore => 1));
+		};
+
+		it "doesn't log an error" => sub {
+		    enqueue_testvolume(ignore => 1);
+		    ok(!$testlog->matches(qr(ERROR)));
+		};
+
+		it "doesn't add a message to the message queue" => sub {
+		    my $receiver = HTFeed::Bunnies->new();
+		    $receiver->reset_queue;
+		    enqueue_testvolume(ignore => 1);
+		    ok(!$receiver->next_job(RECV_WAIT));
+		}
+	    };
+	};
+
+	describe "without bib data" => sub {
+	    describe "without the no_bibdata_ok flag" => sub {
+		it "logs a warning" => sub {
+		    enqueue_testvolume;
+		    ok($testlog->matches(qr(WARN.*bib.*data)));
+		};
+		it "returns false" => sub {
+		    ok(!enqueue_testvolume);
+		};
+		it "doesn't add a message to the queue" => sub {
+		    enqueue_testvolume;
+		    ok(!HTFeed::Bunnies->new->next_job(RECV_WAIT));
+		};
+		it "doesn't put the item in the database" => sub {
+		    enqueue_testvolume;
+		    ok(!get_vol_from_queue);
+		};
+	    };
+
+	    describe "with the no_bibdata_ok flag" => sub {
+		it "returns true" => sub {
+		    ok(enqueue_testvolume(no_bibdata_ok => 1));
+		};
+		it "puts the item in the database" => sub {
+		    enqueue_testvolume(no_bibdata_ok => 1);
+		    ok(get_vol_from_queue);
+		};
+		it "puts the item in the message queue" => sub {
+		    enqueue_testvolume(no_bibdata_ok => 1);
+		    is_testvolume_ready();
+		};
+	    };
+	};
+
+	describe "with a disallowed item" => sub {
+	    before each => sub {
+		fake_bibdata(testvolume);
+		my $sql = join(
+		    " ",
+		    "INSERT INTO feed_queue_disallow",
+		    "VALUES ('test', 'test', 'disallow test item', CURRENT_TIMESTAMP)"
+		);
+		get_dbh()->do($sql);
+	    };
+
+	    context "with default use_disallow_list" => sub {
+		it "logs a warning" => sub {
+		    enqueue_testvolume();
+		    ok($testlog->matches(qr(WARN.*disallow)));
+		};
+		it "returns false" => sub {
+		    ok(!enqueue_testvolume);
+		};
+		it "doesn't put the item in the database" => sub {
+		    enqueue_testvolume;
+		    ok(!get_vol_from_queue);
+		};
+		it "doesn't put the item in the message queue" => sub {
+		    enqueue_testvolume;
+		    ok(!HTFeed::Bunnies->new->next_job(RECV_WAIT));
+		};
+	    };
+
+	    context "with use_disallow_list = 0" => sub {
+		it "returns true" => sub {
+		    ok(enqueue_testvolume(use_disallow_list => 0));
+		};
+		it "puts the item in the database" => sub {
+		    enqueue_testvolume(use_disallow_list => 0);
+		    ok(get_vol_from_queue);
+		};
+		it "puts the item in the message queue" => sub {
+		    enqueue_testvolume(use_disallow_list => 0);
+		    is_testvolume_ready();
+		};
+	    };
+	};
     };
 
-    describe "with reset level 1" => sub {
-      it "resets a punted volume in the database" => sub {
-        my $queue = HTFeed::Queue->new;
-        $queue->enqueue(volume=>testvolume, status=>'punted');
-        $queue->reset(volume=>testvolume, reset_level => 1);
-        ok(volume_in_feed_queue(testvolume, 'ready'));
-      };
+    describe "reset" => sub {
+	before each => sub {
+	    fake_bibdata(testvolume);
+	};
+	it "requires reset level argument" => sub {
+	    enqueue_testvolume(status => 'punted');
+	    throws_ok {
+		HTFeed::Queue->new->reset(volume => testvolume)
+	    } qr(Reset level)
+	};
 
-      it "accepts a priority" => sub {
-        my $queue = HTFeed::Queue->new;
-        my $priority = HTFeed::Queue::QUEUE_PRIORITY_LOW;
-        $queue->enqueue(volume=>testvolume, status=>'punted');
-        $queue->reset(volume=>testvolume, reset_level => 1, priority => $priority);
+	describe "with reset level 1" => sub {
+	    it "resets a punted volume in the database" => sub {
+		enqueue_testvolume(status => 'punted');
+		queue_reset;
+		ok(get_vol_from_queue);
+	    };
+	    it "accepts a priority" => sub {
+		my $priority = HTFeed::Queue::QUEUE_PRIORITY_LOW;
+		enqueue_testvolume(status => 'punted');
+		queue_reset(priority => $priority);
+		my $job = HTFeed::Bunnies->new()->next_job(RECV_WAIT);
+		is($job->{msg}{props}{priority}, $priority);
+	    };
 
-        my $job = HTFeed::Bunnies->new()->next_job(RECV_WAIT);
-        is($job->{msg}{props}{priority}, $priority);
-      };
+	    xit "resets the priority in the database";
 
-      it "resets the priority in the database";
+            it "re-queues a message for a punted volume" => sub {
+                my $receiver = HTFeed::Bunnies->new;
+                enqueue_testvolume(status => 'punted');
+                $receiver->reset_queue;
+                queue_reset;
+                is_testvolume_ready();
+            };
+            it "does not reset a done volume" => sub {
+                enqueue_testvolume(status => 'done');
+                queue_reset;
+                ok(!get_vol_from_queue);
+                ok(!HTFeed::Bunnies->new->next_job(RECV_WAIT));
+            };
 
-      it "re-queues a message for a punted volume" => sub {
-        my $queue = HTFeed::Queue->new;
-        my $receiver = HTFeed::Bunnies->new;
-        $queue->enqueue(volume=>testvolume, status=>'punted');
-        $receiver->reset_queue;
-        
-        $queue->reset(volume=>testvolume, reset_level => 1);
-        test_job_queued_for_volume(testvolume,'ready');
-      };
-
-      it "does not reset a done volume" => sub {
-        my $queue = HTFeed::Queue->new;
-        $queue->enqueue(volume=>testvolume, status=>'done');
-        $queue->reset(volume=>testvolume, reset_level => 1);
-        ok(!volume_in_feed_queue(testvolume, 'ready'));
-        ok(!HTFeed::Bunnies->new->next_job(RECV_WAIT));
-      };
-
-      describe "when resetting to available state" => sub {
-        it "resets a punted volume" => sub {
-          my $queue = HTFeed::Queue->new;
-          $queue->enqueue(volume=>testvolume, status=>'punted');
-          $queue->reset(volume=>testvolume, reset_level => 1, status=>'available');
-          ok(volume_in_feed_queue(testvolume, 'available'));
+            describe "when resetting to available state" => sub {
+                it "resets a punted volume" => sub {
+                    enqueue_testvolume(status => 'punted');
+                    queue_reset(status => 'available');
+                    ok(get_vol_from_queue(testvolume, 'available'));
+                };
+                it "does not queue a message" => sub {
+                    enqueue_testvolume(status => 'punted');
+                    queue_reset(status => 'available');
+                    ok(!HTFeed::Bunnies->new->next_job(RECV_WAIT));
+                };
+            };
         };
 
-        it "does not queue a message" => sub {
-          my $queue = HTFeed::Queue->new;
-          $queue->enqueue(volume=>testvolume, status=>'punted');
-          $queue->reset(volume=>testvolume, reset_level => 1, status=>'available');
-          ok(!HTFeed::Bunnies->new->next_job(RECV_WAIT));
+        describe "with reset level 2" => sub {
+            it "resets a done volume in the database" => sub {
+                enqueue_testvolume(status => 'done');
+                queue_reset(reset_level => 2);
+                ok(get_vol_from_queue);
+            };
+            it "re-queues a message for a done volume" => sub {
+                enqueue_testvolume(status => 'done');
+                HTFeed::Bunnies->new->reset_queue;
+                queue_reset(reset_level => 2);
+                is_testvolume_ready();
+            };
+            it "does not reset an in-flight volume" => sub {
+                enqueue_testvolume(status => 'handled');
+                HTFeed::Bunnies->new->reset_queue;
+                queue_reset(reset_level => 2);
+                ok(!get_vol_from_queue);
+                ok(!HTFeed::Bunnies->new->next_job(RECV_WAIT));
+            };
         };
-      };
+
+        describe "with reset level 3" => sub {
+            it "resets an in-flight volume in the database" => sub {
+                enqueue_testvolume(status => 'handled');
+                queue_reset(reset_level => 3);
+                ok(get_vol_from_queue);
+            };
+            it "re-queues a message for an in-flight volume" => sub {
+                enqueue_testvolume(status => 'handled');
+                HTFeed::Bunnies->new->reset_queue;
+                queue_reset(reset_level => 3);
+                is_testvolume_ready();
+            };
+            it "updates an 'available' item to 'ready'" => sub {
+                enqueue_testvolume(status => 'available');
+                queue_reset(
+                    reset_level => 3,
+                    status      => 'ready'
+                );
+                ok(get_vol_from_queue);
+            };
+            it "queues a message when changing 'available' to 'ready'" => sub {
+                enqueue_testvolume(status => 'available');
+                HTFeed::Bunnies->new->reset_queue;
+                queue_reset(
+                    reset_level => 3,
+                    status      => 'ready'
+                );
+                is_testvolume_ready();
+            };
+            it "uses the priority when initially queued when changing 'available' to 'ready'" => sub {
+                my $priority = 2;
+                enqueue_testvolume(
+                    status   => 'available',
+                    priority => $priority
+                );
+                HTFeed::Bunnies->new->reset_queue;
+                queue_reset(
+                    reset_level => 3,
+                    status      => 'ready'
+                );
+                my $job = HTFeed::Bunnies->new()->next_job(RECV_WAIT);
+                is($job->{msg}{props}{priority}, $priority);
+            };
+        };
     };
 
-    describe "with reset level 2" => sub {
-      it "resets a done volume in the database" => sub {
-        my $queue = HTFeed::Queue->new;
-        $queue->enqueue(volume=>testvolume, status=>'done');
-        $queue->reset(volume=>testvolume, reset_level => 2);
-        ok(volume_in_feed_queue(testvolume, 'ready'));
-      };
+    describe "send_to_message_queue" => sub {
+        it "with ready status, sends a message" => sub {
+            HTFeed::Queue->new->send_to_message_queue(testvolume, 'ready');
+            is_testvolume_ready();
+        };
 
-      it "re-queues a message for a done volume" => sub {
-        my $queue = HTFeed::Queue->new;
-        $queue->enqueue(volume=>testvolume, status=>'done');
-        HTFeed::Bunnies->new->reset_queue;
-        
-        $queue->reset(volume=>testvolume, reset_level => 2);
-        test_job_queued_for_volume(testvolume,'ready');
-      };
-
-      it "does not reset an in-flight volume" => sub {
-        my $queue = HTFeed::Queue->new;
-        $queue->enqueue(volume=>testvolume, status=>'handled');
-        HTFeed::Bunnies->new->reset_queue;
-
-        $queue->reset(volume=>testvolume, reset_level => 2);
-        ok(!volume_in_feed_queue(testvolume, 'ready'));
-        ok(!HTFeed::Bunnies->new->next_job(RECV_WAIT));
-      };
+        it "with available status, does not send a message" => sub {
+            HTFeed::Queue->new->send_to_message_queue(testvolume, 'available');
+            ok(!HTFeed::Bunnies->new->next_job(RECV_WAIT));
+        };
     };
-
-    describe "with reset level 3" => sub {
-      it "resets an in-flight volume in the database" => sub {
-        my $queue = HTFeed::Queue->new;
-        $queue->enqueue(volume=>testvolume, status=>'handled');
-        $queue->reset(volume=>testvolume, reset_level => 3);
-        ok(volume_in_feed_queue(testvolume, 'ready'));
-      };
-
-      it "re-queues a message for an in-flight volume" => sub {
-        my $queue = HTFeed::Queue->new;
-        $queue->enqueue(volume=>testvolume, status=>'handled');
-        HTFeed::Bunnies->new->reset_queue;
-        
-        $queue->reset(volume=>testvolume, reset_level => 3);
-        test_job_queued_for_volume(testvolume,'ready');
-      };
-
-      it "updates an 'available' item to 'ready'" => sub {
-        my $queue = HTFeed::Queue->new;
-        $queue->enqueue(volume=>testvolume, status=>'available');
-        $queue->reset(volume=>testvolume, reset_level => 3, status => 'ready');
-        ok(volume_in_feed_queue(testvolume, 'ready'));
-      };
-
-      it "queues a message when changing 'available' to 'ready'" => sub {
-        my $queue = HTFeed::Queue->new;
-        $queue->enqueue(volume=>testvolume, status=>'available');
-        HTFeed::Bunnies->new->reset_queue;
-        
-        $queue->reset(volume=>testvolume, reset_level => 3, status => 'ready');
-        test_job_queued_for_volume(testvolume,'ready');
-      };
-
-      it "uses the priority when initially queued when changing 'available' to 'ready'" => sub {
-        my $queue = HTFeed::Queue->new;
-        my $priority = 2;
-        $queue->enqueue(volume=>testvolume, status=>'available', priority => $priority);
-        HTFeed::Bunnies->new->reset_queue;
-        
-        $queue->reset(volume=>testvolume, reset_level => 3, status => 'ready');
-        my $job = HTFeed::Bunnies->new()->next_job(RECV_WAIT);
-        is($job->{msg}{props}{priority}, $priority);
-      };
-    };
-
-  };
-
-  describe "send_to_message_queue" => sub {
-    
-    it "with ready status, sends a message" => sub {
-      HTFeed::Queue->new->send_to_message_queue(testvolume,'ready');
-      test_job_queued_for_volume(testvolume,'ready');
-    };
-
-    it "with available status, does not send a message" => sub {
-      HTFeed::Queue->new->send_to_message_queue(testvolume,'available');
-      ok(!HTFeed::Bunnies->new->next_job(RECV_WAIT));
-    };
-  };
 
 };
 


### PR DESCRIPTION
`bin/enqueue.pl` is an important script for doing operational ingest work, but has not had any tests and is (according to the originating ticket) sometimes behaving oddly. I have been unable to replicate the error condition as described in the originating ticket, but: 

* tidied `t/queue.t`
* added `t/enqueue.t` (for testing `bin/enqueue.pl`)

Having `t/enqueue.t` will make it easier to test the error condition if/when I ever get closer to it.
