### PR TITLE
bugfix for DEV-1337

### DIFF
--- a/lib/HTFeed/Stage/ImageRemediate.pm
+++ b/lib/HTFeed/Stage/ImageRemediate.pm
@@ -818,13 +818,18 @@ sub expand_lossless_jpeg2000 {
 
                 # Single quality level with reqested PSNR of 32dB. See DEV-10
                 $start_time = $self->{job_metrics}->time;
-                HTFeed::Image::Grok::compress("$path/$tiff", "$path/$jpeg2000_remediated")
-                and $self->set_error(
-                    "OperationFailed",
-                    operation => "grk_compress",
-                    file      => "$path/$tiff",
-                    detail    => "grk_compress returned $?"
+                my $grk_compress_success = HTFeed::Image::Grok::compress(
+                    "$path/$tiff",
+                    "$path/$jpeg2000_remediated"
                 );
+                if (!$grk_compress_success) {
+                    $self->set_error(
+                        "OperationFailed",
+                        operation => "grk_compress",
+                        file      => "$path/$tiff",
+                        detail    => "grk_compress returned $?"
+                    );
+                }
                 $labels = {
                     converted => "tiff->jpeg2000",
                     tool      => 'grk_decompress'

--- a/t/image.t
+++ b/t/image.t
@@ -109,6 +109,18 @@ describe "HTFeed::Image" => sub {
         check_outfile($out);
         bigger_than($in, $out);
     };
+    it "catches error code in dollar-questionmark" => sub {
+        cp_to_test("circuit_grayscale.tif");
+        my $in   = "$test_dir/circuit_grayscale.tif";
+        # bad extension ".bork", should trigger failure
+        my $out  = "$test_dir/circuit_grayscale_out.bork";
+        my $res  = HTFeed::Image::Grok::compress($in, $out);
+        # expecting failure
+        ok($res == 0);
+        # expecting a non-zero failure code
+        my $error_code = $?;
+        ok($error_code > 0);
+    };
 };
 
 runtests unless caller;


### PR DESCRIPTION
This bug was caused by a change in return value semantics and an incomplete handling of that change.

The return value in question used to be an error code that went straight to error reporting unless zero.

Original, paraphrased:
```
system("foo") and  # 0 good, 1+ bad
report_error();
```

I changed the return value to be a success value instead, while putting the system call inside a wrapper class, but didn't fix the handling of the value in one of the classes using the new wrapper. This resulted in success going straight to error reporting.

I've now made the proper changes to the handling of that return value, so that success counts as success again.
It's a bit wordier but I prefer that.

Improved, paraphrased:
```
$success = wrapper_to_system_call("foo"); # 0 bad, 1 good
report_error() if !$success;
```