### PR TITLE
Update Dockerfile for progress_tracker v0.11.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,7 +79,7 @@ COPY ./Makefile.PL $FEED_HOME/Makefile.PL
 
 RUN cpanm --notest -l /extlib \
   https://github.com/hathitrust/metslib.git@v1.0.1 \
-  https://github.com/hathitrust/progress_tracker.git@v0.9.0
+  https://github.com/hathitrust/progress_tracker.git@v0.11.0
 
 RUN cpanm --notest -l /extlib --skip-satisfied --installdeps .
 


### PR DESCRIPTION
Use the latest progress tracker package.

Not sure if we really need to be pinning here or if it's more trouble than it's worth.