### PR TITLE
pinned to `RabbitMQ-2.40014` in MakeFile

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -22,7 +22,7 @@ WriteMakefile(
     'Mail::Mailer'        => 0,
     'METS'                => 0,
     'Mouse'               => 0,
-    'Net::AMQP::RabbitMQ' => "== 2.40010",
+    'Net::AMQP::RabbitMQ' => "== 2.40014",
     'Prometheus::Tiny::Shared' => 0,
     'ProgressTracker'     => 0,
     'Readonly'            => 0,


### PR DESCRIPTION
For https://hathitrust.atlassian.net/browse/ETT-60.

Updating the RabbitMQ perl module to the current latest version https://metacpan.org/release/MSTEMLE/Net-AMQP-RabbitMQ-2.40014/