### PR TITLE
ensuring resolution does not contain `ppi`

### DIFF
--- a/lib/HTFeed/PackageType/IA/ImageRemediate.pm
+++ b/lib/HTFeed/PackageType/IA/ImageRemediate.pm
@@ -29,6 +29,7 @@ sub run {
     if (not defined $resolution or !$resolution) {
 	$resolution = $volume->get_meta_xpc()->findvalue("//ppi");
     }
+    $resolution =~ s/ppi//;
 
     # decompress any lossless JPEG2000 images
     my @jp2 = glob("$preingest_dir/*.jp2");
@@ -63,7 +64,6 @@ sub run {
     ) if @tiffs;
 
     opendir(my $dirh, "$preingest_dir") or croak("Can't opendir $preingest_dir: $!");
-
     while (my $file = readdir($dirh)) {
         next unless $file =~ /(\d{4})\.jp2$/;
 
@@ -82,8 +82,9 @@ sub run {
         if (my $capture_time = $self->get_capture_time($file)) {
             $set_if_undefined_fields->{'XMP-tiff:DateTime'} = $capture_time;
         }
-
-        $set_if_undefined_fields->{'Resolution'} = $resolution if defined $resolution and $resolution;
+        if (defined $resolution and $resolution) {
+            $set_if_undefined_fields->{'Resolution'} = $resolution;
+        }
 
         $self->remediate_image(
             $jp2_submitted,


### PR DESCRIPTION
Fix for https://hathitrust.atlassian.net/browse/GS-13230

... in which some of `bc`'s IA items were failing because they fall back on an invalid resolution value from the `$volume`.
Single line fix that removes `ppi` from resolution values.

This should fail on the main branch:
```
$ git checkout main
$ docker compose run --rm test perl bin/ingest_ia_dev.pl realceduladesuma00spai_0 test ark:/13960/s25zng884bb
[...]
Error setting new tag Resolution => 400ppi: Not a floating point number for MIE-Image:Resolution
```
... but should succeed on this PR branch:

```
$ git checkout GS-13230-ppi-resolution-fix
$ docker compose run --rm test perl bin/ingest_ia_dev.pl realceduladesuma00spai_0 test ark:/13960/s25zng884bb
```