### PR TITLE
Fix failing tests on Mac

### DIFF
--- a/t/lib/HTFeed/Namespace/ClassTest.pm
+++ b/t/lib/HTFeed/Namespace/ClassTest.pm
@@ -1,4 +1,4 @@
-package HTFeed::Namespace::Test;
+package HTFeed::Namespace::ClassTest;
 
 use warnings;
 use strict;

--- a/t/lib/HTFeed/Test/Class.pm
+++ b/t/lib/HTFeed/Test/Class.pm
@@ -7,10 +7,12 @@ use HTFeed::Config qw(get_config);
 use File::Path qw(remove_tree);
 
 # return testing class, with assumption that $class eq "$testing_class::Test"
+# or for example "$testing_class::SomethingTest"
+
 sub testing_class{
     my $self = shift;
     my $class = ref $self;
-    $class =~ s/::Test$//;
+    $class =~ s/::\w*Test$//;
     return $class;
 }
 

--- a/t/lib/HTFeed/Test/Support.pm
+++ b/t/lib/HTFeed/Test/Support.pm
@@ -56,9 +56,10 @@ my @test_classes;
     my $libDir = "$FindBin::Bin/lib/";
     # get the path to each test classes
     find(sub{
-            if (-f and $_ =~ /^Test\.pm$/ ){
+            if (-f and $_ =~ /Test\.pm$/ ){
                 my $name = $File::Find::name;
                 $name =~ s/$libDir//;
+                return if $name =~ /AbstractTest\.pm$/;
                 push @test_classes, $name;
             }
         }, $libDir


### PR DESCRIPTION
The Mac filesystem is case-preserving but not case sensitive, and t/lib/HTFeed/Namespace/Test.pm appears to conflict with lib/HTFeed/Namespace/TEST.pm. This appears to fix that issue.

@moseshll I'm opening a separate draft PR for this so you can test it independently of the work on #168, but I am going to pull this commit in over there so I can test the versitygw issues without other things interfering.