### PR TITLE
ETT-780: Bucket root contains obj dir

### DIFF
--- a/lib/HTFeed/Storage/PairtreeObjectStore.pm
+++ b/lib/HTFeed/Storage/PairtreeObjectStore.pm
@@ -12,7 +12,7 @@ sub object_path {
   my $self = shift;
 
   return sprintf(
-      '%s/%s%s/',
+      'obj/%s/%s%s/',
       $self->{namespace},
       id2ppath($self->{objid}),
       s2ppchars($self->{objid})

--- a/t/collate.t
+++ b/t/collate.t
@@ -266,10 +266,10 @@ describe "HTFeed::Collate" => sub {
 
         my $s3_timestamp = $s3_backup->[0][0];
 
-        ok($s3s{ptobj1}->s3_has("$pt_path/test.mets.xml"));
-        ok($s3s{ptobj1}->s3_has("$pt_path/test.zip"));
-        ok($s3s{ptobj2}->s3_has("$pt_path/test.mets.xml"));
-        ok($s3s{ptobj2}->s3_has("$pt_path/test.zip"));
+        ok($s3s{ptobj1}->s3_has("obj/$pt_path/test.mets.xml"));
+        ok($s3s{ptobj1}->s3_has("obj/$pt_path/test.zip"));
+        ok($s3s{ptobj2}->s3_has("obj/$pt_path/test.mets.xml"));
+        ok($s3s{ptobj2}->s3_has("obj/$pt_path/test.zip"));
         ok($s3s{backup}->s3_has("test.test.$s3_timestamp.zip.gpg"));
         ok($s3s{backup}->s3_has("test.test.$s3_timestamp.mets.xml"));
 

--- a/t/storage_pairtree_object_store.t
+++ b/t/storage_pairtree_object_store.t
@@ -20,8 +20,8 @@ describe "HTFeed::Storage::PairtreeObjectStore" => sub {
   };
 
   before all => sub {
-    $bucket_dir = "$vgw_home/$bucket";
-    $objdir = "$vgw_home/$bucket-obj";
+    $bucket_dir = "$vgw_home/$bucket/obj";
+    $objdir = "$vgw_home/$bucket-obj/obj";
     make_path($objdir);
   };
 
@@ -48,7 +48,7 @@ describe "HTFeed::Storage::PairtreeObjectStore" => sub {
     it "includes the namespace, pairtree path, and pairtreeized object id" => sub {
       my $storage = object_storage('test','ark:/123456/abcde');
 
-      is($storage->object_path, "test/pairtree_root/ar/k+/=1/23/45/6=/ab/cd/e/ark+=123456=abcde/");
+      is($storage->object_path, "obj/test/pairtree_root/ar/k+/=1/23/45/6=/ab/cd/e/ark+=123456=abcde/");
     };
   };
 
@@ -59,8 +59,8 @@ describe "HTFeed::Storage::PairtreeObjectStore" => sub {
       $storage->move;
 
       # should be in the bucket and also visible in the filesystem
-      ok($s3->s3_has("$pt_path/test.zip"));
-      ok($s3->s3_has("$pt_path/test.mets.xml"));
+      ok($s3->s3_has("obj/$pt_path/test.zip"));
+      ok($s3->s3_has("obj/$pt_path/test.mets.xml"));
       ok(-s "$bucket_dir/$pt_path/test.zip");
       ok(-s "$bucket_dir/$pt_path/test.mets.xml");
     };


### PR DESCRIPTION
@rrotter When testing before I had assumed that the root of the bucket corresponded to the 'obj' dir. However in the setup you have the bucket points to `/sdr1` rather than `/sdr1/obj`. That works but needed some adjustment in the ingest code. Let me know if you think it would be preferable to have the bucket point to `/sdr1/obj` -- I don't have a strong preference.