### PR TITLE
ETT-1363: ImageMagick 7 policy file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ RUN echo "deb [signed-by=/etc/apt/keyrings/mlibrary-archive-keyring.gpg] https:/
 RUN apt-get update && apt-get install grokj2k
 
 
-COPY etc/imagemagick-policy.xml /etc/ImageMagick-6/policy.xml
+COPY etc/imagemagick-policy.xml /etc/ImageMagick-7/policy.xml
 
 COPY etc/jhove-auto-install.xml /tmp/jhove-auto-install.xml
 RUN curl -L https://software.openpreservation.org/releases/jhove/1.34/jhove-installer-1.34.0.jar -o /tmp/jhove-installer.jar

--- a/etc/imagemagick-policy.xml
+++ b/etc/imagemagick-policy.xml
@@ -1,30 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE policymap [
-  <!ELEMENT policymap (policy)*>
-  <!ATTLIST policymap xmlns CDATA #FIXED ''>
-  <!ELEMENT policy EMPTY>
-  <!ATTLIST policy xmlns CDATA #FIXED '' domain NMTOKEN #REQUIRED
-    name NMTOKEN #IMPLIED pattern CDATA #IMPLIED rights NMTOKEN #IMPLIED
-    stealth NMTOKEN #IMPLIED value CDATA #IMPLIED>
+<!ELEMENT policymap (policy)*>
+<!ATTLIST policymap xmlns CDATA #FIXED "">
+<!ELEMENT policy EMPTY>
+<!ATTLIST policy xmlns CDATA #FIXED "">
+<!ATTLIST policy domain NMTOKEN #REQUIRED>
+<!ATTLIST policy name NMTOKEN #IMPLIED>
+<!ATTLIST policy pattern CDATA #IMPLIED>
+<!ATTLIST policy rights NMTOKEN #IMPLIED>
+<!ATTLIST policy stealth NMTOKEN #IMPLIED>
+<!ATTLIST policy value CDATA #IMPLIED>
 ]>
 <policymap>
-<!-- Adapted from default Debian 11 /etc/ImageMagick6/policy.xml, 
+<!-- Default from Debian 13 -->
+  <policy domain="Undefined" rights="none"/>
+<!-- Adapted from default Debian 13 /etc/ImageMagick-7/policy.xml, 
      with greatly increased resource limits to handle large images  -->
-  <policy domain="resource" name="memory" value="2GiB"/>
-  <policy domain="resource" name="map" value="4GiB"/>
+  <policy domain="resource" name="memory" value="2048MiB"/>
+  <policy domain="resource" name="map" value="4096MiB"/>
+  <policy domain="resource" name="area" value="1024MP"/>
+  <policy domain="resource" name="disk" value="512GiB"/>
   <policy domain="resource" name="width" value="1MP"/>
   <policy domain="resource" name="height" value="1MP"/>
-  <policy domain="resource" name="area" value="1GB"/>
-  <policy domain="resource" name="disk" value="16EB"/>
-<!-- Defaults from Debian 11 -->
+<!-- Defaults from Debian 13 -->
+  <policy domain="path" rights="none" pattern="@*"/>
   <policy domain="delegate" rights="none" pattern="URL" />
   <policy domain="delegate" rights="none" pattern="HTTPS" />
   <policy domain="delegate" rights="none" pattern="HTTP" />
-  <policy domain="path" rights="none" pattern="@*"/>
-  <policy domain="coder" rights="none" pattern="PS" />
-  <policy domain="coder" rights="none" pattern="PS2" />
-  <policy domain="coder" rights="none" pattern="PS3" />
-  <policy domain="coder" rights="none" pattern="EPS" />
-  <policy domain="coder" rights="none" pattern="PDF" />
-  <policy domain="coder" rights="none" pattern="XPS" />
 </policymap>


### PR DESCRIPTION
Update ImageMagick policy file for ImageMagick 7 syntax / Debian 13 defaults and put it in the right place