### PR TITLE
Build multiplatform image by default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ on:
             platforms:
                 description: Platforms to build for
                 type: choice
-                default: linux/amd64
+                default: linux/amd64,linux/arm64
                 options:
                 - linux/amd64,linux/arm64
                 - linux/amd64


### PR DESCRIPTION
This used in development/downstream by feed internal so we want multiplatform by default here