### PR TITLE
ETT-1393 - small fixes for IA ingest

### DIFF
--- a/lib/HTFeed/Image/Grok.pm
+++ b/lib/HTFeed/Image/Grok.pm
@@ -5,6 +5,7 @@ use warnings;
 
 use HTFeed::Config qw(get_config);
 use HTFeed::Image::Shared;
+use Log::Log4perl qw(get_logger);
 
 # This package contains all of the system calls to grok.
 # They used to be buried deep in ImageRemediate, hard to test.
@@ -56,6 +57,8 @@ sub compress {
         "> /dev/null 2>&1"
     );
 
+    get_logger()->trace("compressing: '$full_cmd'");
+
     my $sys_ret_val = system($full_cmd);
 
     return !$sys_ret_val;
@@ -81,6 +84,7 @@ sub decompress {
         "-o '$outfile'",
         "> /dev/null 2>&1"
     );
+    get_logger()->trace("decompressing: '$full_cmd'");
     my $sys_ret_val = system($full_cmd);
 
     return !$sys_ret_val;

--- a/lib/HTFeed/PackageType/IA.pm
+++ b/lib/HTFeed/PackageType/IA.pm
@@ -143,6 +143,7 @@ our $config = {
                 v_same( 'xmp', 'xRes', 'xmp', 'yRes' )
             ),
             'layers' => v_in( 'codingStyleDefault', 'layers', ['1','8'] ),
+            'decomposition_levels' => v_between( 'codingStyleDefault', 'decompositionLevels', '1', '32')
         }
     },
 

--- a/lib/HTFeed/Stage/ImageRemediate.pm
+++ b/lib/HTFeed/Stage/ImageRemediate.pm
@@ -106,7 +106,7 @@ sub remediate_image {
   my $self    = shift;
   my $oldfile = shift;
   # dispatch to appropriate remediator
-  $oldfile =~ /\.(.+?)$/;
+  $oldfile =~ /\.(\w+)$/;
   my $oldext = $1;
   # Possibly plug in other extension-specific remediators here?
   if ($oldext eq "jp2") {


### PR DESCRIPTION
* ImageRemediate: handle filenames with embedded '.' characters (previously confused file type detection for items with IA IDs containing '.' characters)

* Log grok command line at TRACE level

* Accept 1 <= DecompositionLevels <= 32 for IA material in general