### PR TITLE
ETT-1502: collate uses volume directly to determine repeat

### DIFF
--- a/lib/HTFeed/Stage/Collate.pm
+++ b/lib/HTFeed/Stage/Collate.pm
@@ -26,102 +26,103 @@ HTFeed::Stage::Collate
 =cut
 
 sub storages {
-    my $self = shift;
-    return HTFeed::Storage::for_volume($self->{volume});
+  my $self = shift;
+  return HTFeed::Storage::for_volume($self->{volume});
 }
 
 sub run{
-    my $self = shift;
+  my $self = shift;
 
-    $self->{is_repeat} = 0;
-    my @storages       = @_;
-    @storages          = $self->storages unless @storages;
+  $self->{is_repeat} = 0;
+  my @storages       = @_;
+  @storages          = $self->storages unless @storages;
 
-    foreach my $storage (@storages) {
-	if ($self->collate($storage)) {
-	    get_logger->trace("finished collate to $storage, cleaning up");
-	    $storage->cleanup
-	} else {
-	    get_logger->warn("collate to $storage failed, rolling back");
-	    $storage->rollback;
-	}
-
-	$storage->clean_staging();
-	$self->check_errors($storage);
-	$self->log_repeat($storage);
+  foreach my $storage (@storages) {
+    if ($self->collate($storage)) {
+      get_logger->trace("finished collate to $storage, cleaning up");
+      $storage->cleanup
+    } else {
+      get_logger->warn("collate to $storage failed, rolling back");
+      $storage->rollback;
     }
-    $self->_set_done();
-    $self->{job_metrics}->inc("ingest_collate_items_total");
 
-    return $self->succeeded();
+    $storage->clean_staging();
+    $self->check_errors($storage);
+    $self->log_repeat($storage);
+  }
+  $self->_set_done();
+  $self->{job_metrics}->inc("ingest_collate_items_total");
+
+  return $self->succeeded();
 }
 
 sub log_repeat {
-    my $self    = shift;
-    my $storage = shift;
+  my $self    = shift;
+  my $storage = shift;
 
-    # TODO - move to specific storage class? not really a property of collate as
-    # such
-    if ($storage->{is_repeat}) {
-	$self->{is_repeat} = 1;
-	$self->set_info('Collating volume that is already in repo');
-    }
+  my $volume = $self->{volume};
+
+  if (-e $volume->get_zip_path() && -e $volume->get_mets_path()) {
+    $self->{is_repeat} = 1;
+    $self->set_info('Collating volume that is already in repo');
+  }
+
 }
 
 sub collate {
-    my $self = shift;
-    my $storage = shift;
+  my $self = shift;
+  my $storage = shift;
 
-    get_logger->trace("Starting collate for $storage");
+  get_logger->trace("Starting collate for $storage");
 
-    $storage->validate_zip_completeness &&
-    $storage->encrypt                   &&
-    $storage->verify_crypt              &&
-    $storage->stage                     &&
-    $storage->prevalidate               &&
-    $storage->make_object_path          &&
-    $storage->move                      &&
-    $storage->postvalidate              &&
-    $storage->record_audit;
+  $storage->validate_zip_completeness &&
+  $storage->encrypt                   &&
+  $storage->verify_crypt              &&
+  $storage->stage                     &&
+  $storage->prevalidate               &&
+  $storage->make_object_path          &&
+  $storage->move                      &&
+  $storage->postvalidate              &&
+  $storage->record_audit;
 }
 
 sub check_errors {
-    my $self  = shift;
-    my $stage = shift;
+  my $self  = shift;
+  my $stage = shift;
 
-    foreach my $error (@{$stage->{errors}}) {
-	$self->{failed}++;
-	if (get_config('stop_on_error')) {
-	    croak("STAGE_ERROR");
-	}
+  foreach my $error (@{$stage->{errors}}) {
+    $self->{failed}++;
+    if (get_config('stop_on_error')) {
+      croak("STAGE_ERROR");
     }
+  }
 }
 
 sub success_info {
-    my $self = shift;
+  my $self = shift;
 
-    return "repeat=" . $self->{is_repeat};
+  return "repeat=" . $self->{is_repeat};
 }
 
 sub stage_info{
-    return {
-	success_state => 'collated',
-	failure_state => 'punted'
-    };
+  return {
+    success_state => 'collated',
+    failure_state => 'punted'
+  };
 }
 
 sub clean_always{
-    my $self = shift;
+  my $self = shift;
 
-    $self->{volume}->clean_mets();
-    $self->{volume}->clean_zip();
+  $self->{volume}->clean_mets();
+  $self->{volume}->clean_zip();
 }
 
 sub clean_success {
-    my $self = shift;
+  my $self = shift;
 
-    $self->{volume}->clear_premis_events();
-    $self->{volume}->clean_sip_success();
+  $self->{volume}->clear_premis_events();
+  $self->{volume}->clean_sip_success();
 }
 
 1;

--- a/lib/HTFeed/Storage/LinkedPairtree.pm
+++ b/lib/HTFeed/Storage/LinkedPairtree.pm
@@ -40,7 +40,6 @@ sub make_object_path {
   my $self = shift;
 
   $self->symlink_if_needed;
-  $self->set_is_repeat;
 
   return 1;
 }
@@ -88,7 +87,6 @@ sub symlink_if_needed {
   my $namespace = $self->{namespace};
   my $objid = $self->{objid};
   my $pt_objid = s2ppchars($objid);
-  $self->{is_repeat} = 0;
 
   my $link_parent = $self->link_parent;
   my $link_path = $self->link_path;

--- a/lib/HTFeed/Storage/LocalPairtree.pm
+++ b/lib/HTFeed/Storage/LocalPairtree.pm
@@ -96,24 +96,12 @@ sub existing_object {
     return -f $self->zip_obj_path && -f $self->mets_obj_path;
 }
 
-sub set_is_repeat {
-    my $self = shift;
-
-    if ($self->existing_object) {
-        $self->{is_repeat} = 1;
-    } else {
-        $self->{is_repeat} = 0;
-    }
-}
-
 sub make_object_path {
     my $self = shift;
 
     if (! -d $self->object_path) {
         $self->safe_make_path($self->object_path);
     }
-
-    $self->set_is_repeat;
 
     return 1;
 }

--- a/t/storage_linked_pairtree.t
+++ b/t/storage_linked_pairtree.t
@@ -59,25 +59,8 @@ describe "HTFeed::Storage::LinkedPairtree" => sub {
         is("$tmpdirs->{obj_dir}/test/pairtree_root/te/st/test",
           readlink("$tmpdirs->{link_dir}/test/pairtree_root/te/st/test"));
       };
-
-      it "does not set is_repeat if the object is not in the repo" => sub {
-        my $storage = linked_storage('test','test');
-        $storage->make_object_path;
-
-        ok(!$storage->{is_repeat});
-      }
     };
 
-    context "when the object is in the repo with link target matching obj_dir" => sub {
-      it "sets is_repeat" => sub {
-        make_old_version(linked_storage('test','test'));
-
-        my $storage = linked_storage('test','test');
-        $storage->make_object_path;
-
-        ok($storage->{is_repeat});
-      };
-    };
 
     context "when the object is in the repo but link target doesn't match current obj dir" => sub {
       it "uses existing target of the link" => sub {
@@ -88,15 +71,6 @@ describe "HTFeed::Storage::LinkedPairtree" => sub {
 
         is($storage->object_path,"$tmpdirs->{other_obj_dir}/test/pairtree_root/te/st/test");
       };
-
-      it "sets is_repeat" => sub {
-        make_old_version_other_dir('test','test');
-
-        my $storage = linked_storage('test','test');
-        $storage->make_object_path;
-
-        ok($storage->{is_repeat});
-      }
     };
   };
 

--- a/t/storage_local_pairtree.t
+++ b/t/storage_local_pairtree.t
@@ -48,15 +48,6 @@ describe "HTFeed::Storage::LocalPairtree" => sub {
 
   describe "#make_object_path" => sub {
 
-    context "when the object is not in the repo" => sub {
-      it "does not set is_repeat if the object is not in the repo" => sub {
-        my $storage = local_storage('test','test');
-        $storage->make_object_path;
-
-        ok(!$storage->{is_repeat});
-      }
-    };
-
     it "works" => sub {
       my $storage = local_storage('test','test');
       $storage->make_object_path;


### PR DESCRIPTION
Currently in production, we are no longer using LinkedPairtree or LocalPairtree to deposit material. They were responsible for setting is_repeat. Now, collate checks directly.

This points to a sort of mismatch for how for writing to the repository we have abstracted the repository storage, but not for reading what is in the repository. That might be future work to separate out from Volume.