### PR TITLE
gha updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,8 +46,8 @@ jobs:
                 dockerfile: Dockerfile
                 img_tag: ${{ inputs.img_tag }}
                 tag: ${{ inputs.ref }}
-                push_latest: ${{ inputs.push_latest}}
+                push_latest: ${{ inputs.push_latest || false }}
                 registry_token: ${{ github.token }}
-                rebuild: ${{ inputs.rebuild }}
+                rebuild: ${{ inputs.rebuild || false }}
                 build-args: 'version="commit ${{ github.sha }}"'
                 platforms: ${{ inputs.platforms || 'linux/amd64,linux/arm64' }}

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -11,6 +11,6 @@ jobs:
       - uses: hathitrust/github_actions/tag-release@v1
         with:
           registry_token: ${{ github.token }}
-          existing_tag: ghcr.io/hathitrust/feed-unstable:${{ github.sha }}
+          existing_tag: ghcr.io/hathitrust/feed:${{ github.sha }}
           image: ghcr.io/hathitrust/feed
           new_tag: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
* tag-release shouldn't use unstable
* build should not push latest by default