### PR TITLE
Log only errors and "collate succeeds" messages to feed_log

### DIFF
--- a/etc/config.l4p
+++ b/etc/config.l4p
@@ -1,5 +1,16 @@
 log4perl.rootLogger                     = sub {return HTFeed::Log::get_root_log_config();}
 
+log4perl.filter.error = Log::Log4perl::Filter::LevelMatch
+log4perl.filter.error.LevelToMatch = ERROR
+log4perl.filter.error.AcceptOnMatch = true
+
+log4perl.filter.collate_succeeds = Log::Log4perl::Filter::StringMatch
+log4perl.filter.collate_succeeds.StringToMatch = StageSucceeded.*Collate
+log4perl.filter.collate_succeeds.AcceptOnMatch = true
+
+log4perl.filter.dbi_filter = Log::Log4perl::Filter::Boolean
+log4perl.filter.dbi_filter.logic = error || collate_succeeds
+
 # appender dbi
 log4perl.appender.dbi                   = HTFeed::Log::Appender::DBI
 log4perl.appender.dbi.sql =         \
@@ -12,6 +23,7 @@ log4perl.appender.dbi.params.2 = %p
 log4perl.appender.dbi.layout            = Log::Log4perl::Layout::NoopLayout
 log4perl.appender.dbi.warp_message      = HTFeed::Log::Warp::toDBArray
 log4perl.appender.dbi.utf8           = 1
+log4perl.appender.dbi.Filter = dbi_filter
 
 # appender screen
 log4perl.appender.screen                = Log::Log4perl::Appender::ScreenColoredLevels

--- a/t/dbi_logger.t
+++ b/t/dbi_logger.t
@@ -1,0 +1,48 @@
+use HTFeed::Log { root_logger => 'INFO, dbi, screen' };
+use Log::Log4perl qw(get_logger);
+use HTFeed::DBTools qw(get_dbh);
+use Test::Spec;
+
+describe "HTFeed::Log" => sub {
+  sub first_log_row {
+    get_dbh()->selectrow_arrayref("select message from feed_log");
+  }
+
+  before each => sub {
+    get_dbh()->do("DELETE FROM feed_log");
+  };
+
+  it "does not log level INFO to DB" => sub {
+    get_logger()->info("shouldn't be in db");
+
+    ok(not defined first_log_row());
+  };
+
+  it "logs level ERROR to DB" => sub {
+    get_logger()->error("message");
+
+    is(first_log_row()->[0], "message");
+  };
+
+  # Same logging call as in HTFeed::Job::update
+  it "logs collate succeeded message to DB" => sub {
+    get_logger()->info('StageSucceeded', 
+      namespace => "test", 
+      objid => "test",
+      stage => "HTFeed::Stage::Collate",
+      detail => "repeat=1");
+
+    is(first_log_row()->[0], "Stage succeeded");
+  };
+
+  it "does not log other stage succeeded message to DB" => sub {
+    get_logger()->info('StageSucceeded', 
+      namespace => "test", 
+      objid => "test",
+      stage => "HTFeed::Stage::Handle");
+
+    ok(not defined first_log_row());
+  }
+};
+
+runtests unless caller;


### PR DESCRIPTION
This should cut down significantly on the noise in feed_log, although we still ought to rethink how reporting that uses feed_log works.